### PR TITLE
Remove singleton AudioDevice subclasses

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDevice.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDevice.kt
@@ -2,29 +2,21 @@ package com.twilio.audioswitch.selection
 
 /**
  * This class represents a single audio device that has been retrieved by the [AudioDeviceSelector].
- * @property name the friendly name of the device
  */
 sealed class AudioDevice {
 
+    /** The friendly name of the device.*/
     abstract val name: String
 
-    /**
-     * An [AudioDevice] representing a Bluetooth Headset.
-     */
+    /** An [AudioDevice] representing a Bluetooth Headset.*/
     data class BluetoothHeadset internal constructor(override val name: String) : AudioDevice()
 
-    /**
-     * An [AudioDevice] representing a Wired Headset.
-     */
-    object WiredHeadset : AudioDevice() { override val name: String = "Wired Headset" }
+    /** An [AudioDevice] representing a Wired Headset.*/
+    data class WiredHeadset internal constructor(override val name: String = "Wired Headset") : AudioDevice()
 
-    /**
-     * An [AudioDevice] representing the Earpiece.
-     */
-    object Earpiece : AudioDevice() { override val name: String = "Earpiece" }
+    /** An [AudioDevice] representing the Earpiece.*/
+    data class Earpiece internal constructor(override val name: String = "Earpiece") : AudioDevice()
 
-    /**
-     * An [AudioDevice] representing the Speakerphone.
-     */
-    object Speakerphone : AudioDevice() { override val name: String = "Speakerphone" }
+    /** An [AudioDevice] representing the Speakerphone.*/
+    data class Speakerphone internal constructor(override val name: String = "Speakerphone") : AudioDevice()
 }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceSelector.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceSelector.kt
@@ -109,7 +109,7 @@ class AudioDeviceSelector {
             wiredHeadsetAvailable = true
             logger.d(TAG, "Wired Headset available")
             if (this@AudioDeviceSelector.state == ACTIVATED) {
-                userSelectedDevice = WiredHeadset
+                userSelectedDevice = WiredHeadset()
             }
             enumerateDevices()
         }
@@ -190,11 +190,11 @@ class AudioDeviceSelector {
                 audioDeviceManager.enableSpeakerphone(false)
                 bluetoothController?.activate()
             }
-            Earpiece, WiredHeadset -> {
+            is Earpiece, is WiredHeadset -> {
                 audioDeviceManager.enableSpeakerphone(false)
                 bluetoothController?.deactivate()
             }
-            Speakerphone -> {
+            is Speakerphone -> {
                 audioDeviceManager.enableSpeakerphone(true)
                 bluetoothController?.deactivate()
             }
@@ -249,13 +249,13 @@ class AudioDeviceSelector {
         mutableAudioDevices.clear()
         bluetoothAudioDevice?.let { mutableAudioDevices.add(it) }
         if (wiredHeadsetAvailable) {
-            mutableAudioDevices.add(WiredHeadset)
+            mutableAudioDevices.add(WiredHeadset())
         }
         if (audioDeviceManager.hasEarpiece() && !wiredHeadsetAvailable) {
-            mutableAudioDevices.add(Earpiece)
+            mutableAudioDevices.add(Earpiece())
         }
         if (audioDeviceManager.hasSpeakerphone()) {
-            mutableAudioDevices.add(Speakerphone)
+            mutableAudioDevices.add(Speakerphone())
         }
 
         // Check whether the user selected device is still present

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -115,8 +115,8 @@ class AudioDeviceSelectorTest {
         audioDeviceSelector.start(audioDeviceChangeListener)
 
         verify(audioDeviceChangeListener).invoke(
-                listOf(Earpiece, Speakerphone),
-                Earpiece)
+                listOf(Earpiece(), Speakerphone()),
+                Earpiece())
     }
 
     @Test
@@ -310,7 +310,7 @@ class AudioDeviceSelectorTest {
     @Test
     fun `activate should enable audio routing to the speakerphone device`() {
         audioDeviceSelector.start(audioDeviceChangeListener)
-        audioDeviceSelector.selectDevice(Speakerphone)
+        audioDeviceSelector.selectDevice(Speakerphone())
         audioDeviceSelector.activate()
 
         verify(audioManager).isSpeakerphoneOn = true


### PR DESCRIPTION
Remove use of singletons in AudioDevice subclasses to avoid improper API usage when calling the AudioDeviceSecelctor selectDevice function.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
