### PR TITLE
Remove repository section in Gradle setup instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,6 @@ To get started using this library, follow the steps below.
 
 ### Gradle Setup
 
-Ensure the jcenter repository is configured:
-```
-repositories {
-    jcenter()
-}
-```
-
 Add this line as a new Gradle dependency:
 ```
 implementation 'com.twilio:audioswitch:0.1.0'

--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ To get started using this library, follow the steps below.
 
 ### Gradle Setup
 
-Ensure the jcenter repository is configured:
-```
-repositories {
-    jcenter()
-}
-```
-
 Add this line as a new Gradle dependency:
 ```
 implementation 'com.twilio:audioswitch:0.1.0'


### PR DESCRIPTION
Remove repository section in readme and changelog Gradle setup instructions.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
