### PR TITLE
Fix/audiofocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.1.1
+
+- Fixes bug that did not correctly abandon audio request after deactivate
+
 ### 0.1.0
 
 This release marks the first iteration of the AudioSwitch library: an Android audio management library for real-time communication apps.

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -99,7 +99,7 @@ internal class AudioDeviceManager(
         if (build.getVersion() >= Build.VERSION_CODES.O) {
             audioRequest?.let { audioManager.abandonAudioFocusRequest(it) }
         } else {
-            audioManager.abandonAudioFocus {}
+            audioManager.abandonAudioFocus { }
         }
     }
 }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -13,11 +13,11 @@ import com.twilio.audioswitch.android.LogWrapper
 private const val TAG = "AudioDeviceManager"
 
 internal class AudioDeviceManager(
-        private val context: Context,
-        private val logger: LogWrapper,
-        private val audioManager: AudioManager,
-        private val build: BuildWrapper,
-        private val audioFocusRequest: AudioFocusRequestWrapper
+    private val context: Context,
+    private val logger: LogWrapper,
+    private val audioManager: AudioManager,
+    private val build: BuildWrapper,
+    private val audioFocusRequest: AudioFocusRequestWrapper
 ) {
 
     private var savedAudioMode = 0

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.media.AudioDeviceInfo
+import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
 import com.twilio.audioswitch.android.BuildWrapper
@@ -12,16 +13,17 @@ import com.twilio.audioswitch.android.LogWrapper
 private const val TAG = "AudioDeviceManager"
 
 internal class AudioDeviceManager(
-    private val context: Context,
-    private val logger: LogWrapper,
-    private val audioManager: AudioManager,
-    private val build: BuildWrapper,
-    private val audioFocusRequest: AudioFocusRequestWrapper
+        private val context: Context,
+        private val logger: LogWrapper,
+        private val audioManager: AudioManager,
+        private val build: BuildWrapper,
+        private val audioFocusRequest: AudioFocusRequestWrapper
 ) {
 
     private var savedAudioMode = 0
     private var savedIsMicrophoneMuted = false
     private var savedSpeakerphoneEnabled = false
+    private var audioRequest: AudioFocusRequest? = null
 
     fun hasEarpiece(): Boolean {
         val hasEarpiece = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
@@ -54,7 +56,8 @@ internal class AudioDeviceManager(
     fun setAudioFocus() {
         // Request audio focus before making any device switch.
         if (build.getVersion() >= Build.VERSION_CODES.O) {
-            audioManager.requestAudioFocus(audioFocusRequest.buildRequest())
+            audioRequest = audioFocusRequest.buildRequest()
+            audioRequest?.let { audioManager.requestAudioFocus(it) }
         } else {
             audioManager.requestAudioFocus(
                     {},
@@ -93,6 +96,10 @@ internal class AudioDeviceManager(
         audioManager.mode = savedAudioMode
         mute(savedIsMicrophoneMuted)
         enableSpeakerphone(savedSpeakerphoneEnabled)
-        audioManager.abandonAudioFocus(null)
+        if (build.getVersion() >= Build.VERSION_CODES.O) {
+            audioRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        } else {
+            audioManager.abandonAudioFocus(null)
+        }
     }
 }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -99,7 +99,7 @@ internal class AudioDeviceManager(
         if (build.getVersion() >= Build.VERSION_CODES.O) {
             audioRequest?.let { audioManager.abandonAudioFocusRequest(it) }
         } else {
-            audioManager.abandonAudioFocus(null)
+            audioManager.abandonAudioFocus {}
         }
     }
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -299,7 +299,7 @@ class AudioDeviceSelectorTest {
     }
 
     @Test
-    fun `deactivate should set audio focus using pre Android O method if api version is 26`() {
+    fun `deactivate should abandon audio focus using pre Android O method if api version is 26`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O)
         val audioFocusRequest = mock<AudioFocusRequest>()
         whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
@@ -311,7 +311,7 @@ class AudioDeviceSelectorTest {
     }
 
     @Test
-    fun `deactivate should set audio focus using pre Android O method if api version is 27`() {
+    fun `deactivate should abandon audio focus using pre Android O method if api version is 27`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O_MR1)
         val audioFocusRequest = mock<AudioFocusRequest>()
         whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
@@ -323,13 +323,13 @@ class AudioDeviceSelectorTest {
     }
 
     @Test
-    fun `deactivate should set audio focus using pre Android O method if api version is 25`() {
+    fun `deactivate should abandon audio focus using pre Android O method if api version is 25`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.N_MR1)
         audioDeviceSelector.start(audioDeviceChangeListener)
         audioDeviceSelector.activate()
         audioDeviceSelector.stop()
 
-        verify(audioManager).abandonAudioFocus(null)
+        verify(audioManager).abandonAudioFocus(isA())
     }
 
     @Test

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -299,6 +299,40 @@ class AudioDeviceSelectorTest {
     }
 
     @Test
+    fun `deactivate should set audio focus using pre Android O method if api version is 26`() {
+        whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O)
+        val audioFocusRequest = mock<AudioFocusRequest>()
+        whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
+        audioDeviceSelector.start(audioDeviceChangeListener)
+        audioDeviceSelector.activate()
+        audioDeviceSelector.stop()
+
+        verify(audioManager).abandonAudioFocusRequest(audioFocusRequest)
+    }
+
+    @Test
+    fun `deactivate should set audio focus using pre Android O method if api version is 27`() {
+        whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O_MR1)
+        val audioFocusRequest = mock<AudioFocusRequest>()
+        whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
+        audioDeviceSelector.start(audioDeviceChangeListener)
+        audioDeviceSelector.activate()
+        audioDeviceSelector.stop()
+
+        verify(audioManager).abandonAudioFocusRequest(audioFocusRequest)
+    }
+
+    @Test
+    fun `deactivate should set audio focus using pre Android O method if api version is 25`() {
+        whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.N_MR1)
+        audioDeviceSelector.start(audioDeviceChangeListener)
+        audioDeviceSelector.activate()
+        audioDeviceSelector.stop()
+
+        verify(audioManager).abandonAudioFocus(null)
+    }
+
+    @Test
     fun `activate should enable audio routing to the earpiece`() {
         audioDeviceSelector.start(audioDeviceChangeListener)
         audioDeviceSelector.activate()

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 versionMajor=0
 versionMinor=1
-versionPatch=1
+versionPatch=2

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 versionMajor=0
 versionMinor=1
-versionPatch=2
+versionPatch=1


### PR DESCRIPTION
## Description

Fixes a bug that does not correctly abandon audio focus after disconnect.

## Breakdown

- Audio Focus not correctly abandoned when restoring audio state
- `abandonAudioFocusRequest(focusRequest: AudioFocusRequest)` called for API level >= 26 and `abandonAudioFocus {}` called for API level < 26 similarly to `requestAudioFocus` in the `setAudioFocus()` method.
- Documentation states same listener/focus request that was used for `requestAudioFocus` should be used for `abandonAudioFocus`

## Validation

- Add new unit tests to validate changes

## Additional Notes

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [X] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
