### PR TITLE
AHOYAPPS-611 Add sources to release artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ workflows:
             branches:
               only:
                 - "master"
-                - "task/add-sources-to-artifact"
           requires:
             - unit-tests
             - integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ workflows:
             branches:
               only:
                 - "master"
+                - "task/add-sources-to-artifact"
           requires:
             - unit-tests
             - integration-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.1.2
+
+Enhancements
+
+- Added the library source to release artifacts. The sources will now be available when jumping to a library class definition in Android Studio.
+
 ### 0.1.1
 
 - Fixes bug that did not correctly abandon audio request after deactivate

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -50,6 +50,15 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
 }
 
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.source
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
 uploadArchives {
     repositories {
         mavenDeployer {


### PR DESCRIPTION
## Description

Add sources to release artifacts
## Validation

- Published a test [artifact](https://bintray.com/twilio/internal-releases/audioswitch/0.1.2-329289c) and validated that when consumed in the Video app that the sources are available.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
