### PR TITLE
AHOYAPPS-653: Add additional device classes to support more bluetooth headset devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Enhancements
 
 - Added the library source to release artifacts. The sources will now be available when jumping to a library class definition in Android Studio.
 
+Bug Fixes
+
+- Added a fix for certain valid bluetooth device classes not being considered as headset devices as reported in [issue #16](https://github.com/twilio/audioswitch/issues/16).
+
 ### 0.1.1
 
 - Fixes bug that did not correctly abandon audio request after deactivate

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetReceiver.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetReceiver.kt
@@ -2,7 +2,9 @@ package com.twilio.audioswitch.bluetooth
 
 import android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_CAR_AUDIO
 import android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_HANDSFREE
+import android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_HEADPHONES
 import android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_WEARABLE_HEADSET
+import android.bluetooth.BluetoothClass.Device.Major.UNCATEGORIZED
 import android.bluetooth.BluetoothDevice.ACTION_ACL_CONNECTED
 import android.bluetooth.BluetoothDevice.ACTION_ACL_DISCONNECTED
 import android.content.BroadcastReceiver
@@ -83,6 +85,8 @@ internal class BluetoothHeadsetReceiver(
             deviceWrapper.deviceClass?.let { deviceClass ->
                 deviceClass == AUDIO_VIDEO_HANDSFREE ||
                 deviceClass == AUDIO_VIDEO_WEARABLE_HEADSET ||
-                deviceClass == AUDIO_VIDEO_CAR_AUDIO
+                deviceClass == AUDIO_VIDEO_CAR_AUDIO ||
+                deviceClass == AUDIO_VIDEO_HEADPHONES ||
+                deviceClass == UNCATEGORIZED
             } ?: false
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetReceiverTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetReceiverTest.kt
@@ -50,6 +50,12 @@ class BluetoothHeadsetReceiverTest {
         val audioVideoCarDevice = mock<BluetoothClass> {
             whenever(mock.deviceClass).thenReturn(BluetoothClass.Device.AUDIO_VIDEO_CAR_AUDIO)
         }
+        val headphonesDevice = mock<BluetoothClass> {
+            whenever(mock.deviceClass).thenReturn(BluetoothClass.Device.AUDIO_VIDEO_HEADPHONES)
+        }
+        val uncategorizedDevice = mock<BluetoothClass> {
+            whenever(mock.deviceClass).thenReturn(BluetoothClass.Device.Major.UNCATEGORIZED)
+        }
         val wrongDevice = mock<BluetoothClass> {
             whenever(mock.deviceClass).thenReturn(BluetoothClass.Device.AUDIO_VIDEO_VIDEO_MONITOR)
         }
@@ -57,6 +63,8 @@ class BluetoothHeadsetReceiverTest {
             arrayOf(handsFreeDevice, true),
             arrayOf(audioVideoHeadsetDevice, true),
             arrayOf(audioVideoCarDevice, true),
+            arrayOf(headphonesDevice, true),
+            arrayOf(uncategorizedDevice, true),
             arrayOf(wrongDevice, false),
             arrayOf(null, false)
         )


### PR DESCRIPTION
## Description

Added additional device classes to support more bluetooth headset devices.

## Breakdown

- Added `AUDIO_VIDEO_HEADPHONES` and `UNCATEGORIZED` as additional supported device classes in `BluetoothHeadsetReceiver`.

## Validation

- Passed CI

## Additional Notes

I tried utilizing the BluetoothHeadset proxy object retrieved from the BluetoothAdapter class within the BluetoothDeviceReceiver class as an alternative to checking device classes , but had no luck. I tried referencing the getDevicesMatchingConnectionStates and getConnectedDevices methods from the BluetoothHeadset proxy to check if the device received from the ACTION_ACL_CONNECTED  receiver event was indeed connected, but those methods just returned an empty list. Perhaps our BluetoothDeviceReceiver is receiving events before they are being connected with the BluetoothHeadset proxy. Decided to switch gears and keep it simple by adding more device classes as specified in the reported Github issue #16 .

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
