### PR TITLE
Add default bluetooth device name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.1.3
+
+Bug Fixes
+
+- Fixed crash by adding a default bluetooth device name.
+
 ### 0.1.2
 
 Enhancements

--- a/audioswitch/src/main/java/com/twilio/audioswitch/android/BluetoothDeviceWrapperImpl.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/android/BluetoothDeviceWrapperImpl.kt
@@ -2,10 +2,10 @@ package com.twilio.audioswitch.android
 
 import android.bluetooth.BluetoothDevice
 
-internal const val GENERIC_DEVICE_NAME = "Bluetooth"
+internal const val DEFAULT_DEVICE_NAME = "Bluetooth"
 
 internal class BluetoothDeviceWrapperImpl(
     private val device: BluetoothDevice,
-    override val name: String = device.name ?: GENERIC_DEVICE_NAME,
+    override val name: String = device.name ?: DEFAULT_DEVICE_NAME,
     override val deviceClass: Int? = device.bluetoothClass?.deviceClass
 ) : BluetoothDeviceWrapper

--- a/audioswitch/src/main/java/com/twilio/audioswitch/android/BluetoothDeviceWrapperImpl.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/android/BluetoothDeviceWrapperImpl.kt
@@ -2,8 +2,10 @@ package com.twilio.audioswitch.android
 
 import android.bluetooth.BluetoothDevice
 
+internal const val GENERIC_DEVICE_NAME = "Bluetooth"
+
 internal class BluetoothDeviceWrapperImpl(
     private val device: BluetoothDevice,
-    override val name: String = device.name,
+    override val name: String = device.name ?: GENERIC_DEVICE_NAME,
     override val deviceClass: Int? = device.bluetoothClass?.deviceClass
 ) : BluetoothDeviceWrapper

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -21,7 +21,7 @@ import com.twilio.audioswitch.selection.AudioDeviceSelector.State.ACTIVATED
 import com.twilio.audioswitch.selection.AudioDeviceSelector.State.STARTED
 import com.twilio.audioswitch.selection.AudioDeviceSelector.State.STOPPED
 import com.twilio.audioswitch.android.BuildWrapper
-import com.twilio.audioswitch.android.GENERIC_DEVICE_NAME
+import com.twilio.audioswitch.android.DEFAULT_DEVICE_NAME
 import com.twilio.audioswitch.android.LogWrapper
 import com.twilio.audioswitch.bluetooth.BluetoothController
 import com.twilio.audioswitch.bluetooth.BluetoothControllerAssertions
@@ -84,10 +84,10 @@ class AudioDeviceSelectorTest {
         audioDeviceSelector.bluetoothDeviceConnectionListener.onBluetoothConnected(
                 BluetoothDeviceWrapperImpl(mock()))
 
-        val hasGenericDeviceName = audioDeviceSelector.availableAudioDevices.any {
-            it.name == GENERIC_DEVICE_NAME
+        val hasDefaultDeviceName = audioDeviceSelector.availableAudioDevices.any {
+            it.name == DEFAULT_DEVICE_NAME
         }
-        assertThat(hasGenericDeviceName, equalTo(true))
+        assertThat(hasDefaultDeviceName, equalTo(true))
     }
 
     @Test

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -16,10 +16,12 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import com.twilio.audioswitch.android.BluetoothDeviceWrapper
+import com.twilio.audioswitch.android.BluetoothDeviceWrapperImpl
 import com.twilio.audioswitch.selection.AudioDeviceSelector.State.ACTIVATED
 import com.twilio.audioswitch.selection.AudioDeviceSelector.State.STARTED
 import com.twilio.audioswitch.selection.AudioDeviceSelector.State.STOPPED
 import com.twilio.audioswitch.android.BuildWrapper
+import com.twilio.audioswitch.android.GENERIC_DEVICE_NAME
 import com.twilio.audioswitch.android.LogWrapper
 import com.twilio.audioswitch.bluetooth.BluetoothController
 import com.twilio.audioswitch.bluetooth.BluetoothControllerAssertions
@@ -75,6 +77,18 @@ class AudioDeviceSelectorTest {
                     bluetoothHeadsetReceiver)
     )
     private val bluetoothControllerAssertions = BluetoothControllerAssertions()
+
+    @Test
+    fun `availableAudioDevices should return a generic bluetooth device name if none was returned from the BluetoothDevice class`() {
+        audioDeviceSelector.start(audioDeviceChangeListener)
+        audioDeviceSelector.bluetoothDeviceConnectionListener.onBluetoothConnected(
+                BluetoothDeviceWrapperImpl(mock()))
+
+        val hasGenericDeviceName = audioDeviceSelector.availableAudioDevices.any {
+            it.name == GENERIC_DEVICE_NAME
+        }
+        assertThat(hasGenericDeviceName, equalTo(true))
+    }
 
     @Test
     fun `start should start the bluetooth and wired headset listeners`() {


### PR DESCRIPTION
Fixed crash by adding default bluetooth device name if null is returned from the Android BluetoothDevice class. Resolves issue reported in #22 . 

## Validation

- Passed CI pipeline

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
