### PR TITLE
Don't obfuscate the audio switch library

### DIFF
--- a/audioswitch/proguard-rules.pro
+++ b/audioswitch/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class com.twilio.audioswitch.** { *; }
+-keepattributes InnerClasses


### PR DESCRIPTION
## Description

Add configuration to proguard-rules.pro to ignore all audio switch files for obfuscation.

## Validation

- Manually pushed an artifact to OSS JFrog and tested artifact consumption in the Twilio Video App.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
