### PR TITLE
Fix audio focus issue encountered on pre Oreo devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bug Fixes
 
 - Improved the accuracy of the `BluetoothHeadset` within the `availableAudioDevices` returned from the `AudioDeviceSelector` when multiple Bluetooth Headsets are connected.
+- Fixed a bug where the audio focus wasn't being returned to the previous audio focus owner on pre Oreo devices.
 
 ### 0.1.5
 

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -17,14 +17,15 @@ internal class AudioDeviceManager(
     private val logger: LogWrapper,
     private val audioManager: AudioManager,
     private val build: BuildWrapper,
-    private val audioFocusRequest: AudioFocusRequestWrapper
+    private val audioFocusRequest: AudioFocusRequestWrapper,
+    private val audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener =
+            AudioManager.OnAudioFocusChangeListener { }
 ) {
 
     private var savedAudioMode = 0
     private var savedIsMicrophoneMuted = false
     private var savedSpeakerphoneEnabled = false
     private var audioRequest: AudioFocusRequest? = null
-    private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
 
     fun hasEarpiece(): Boolean {
         val hasEarpiece = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
@@ -60,7 +61,6 @@ internal class AudioDeviceManager(
             audioRequest = audioFocusRequest.buildRequest()
             audioRequest?.let { audioManager.requestAudioFocus(it) }
         } else {
-            audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { }
             audioManager.requestAudioFocus(
                     audioFocusChangeListener,
                     AudioManager.STREAM_VOICE_CALL,

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -24,6 +24,7 @@ internal class AudioDeviceManager(
     private var savedIsMicrophoneMuted = false
     private var savedSpeakerphoneEnabled = false
     private var audioRequest: AudioFocusRequest? = null
+    private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
 
     fun hasEarpiece(): Boolean {
         val hasEarpiece = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
@@ -59,8 +60,9 @@ internal class AudioDeviceManager(
             audioRequest = audioFocusRequest.buildRequest()
             audioRequest?.let { audioManager.requestAudioFocus(it) }
         } else {
+            audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { }
             audioManager.requestAudioFocus(
-                    {},
+                    audioFocusChangeListener,
                     AudioManager.STREAM_VOICE_CALL,
                     AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
         }
@@ -100,7 +102,7 @@ internal class AudioDeviceManager(
         if (build.getVersion() >= Build.VERSION_CODES.O) {
             audioRequest?.let { audioManager.abandonAudioFocusRequest(it) }
         } else {
-            audioManager.abandonAudioFocus { }
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
         }
     }
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -43,6 +43,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.ArgumentCaptor
 
 private const val DEVICE_NAME = "Bluetooth"
 
@@ -348,9 +349,16 @@ class AudioDeviceSelectorTest {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.N_MR1)
         audioDeviceSelector.start(audioDeviceChangeListener)
         audioDeviceSelector.activate()
+        val audioFocusListenerCaptor =
+            ArgumentCaptor.forClass(AudioManager.OnAudioFocusChangeListener::class.java)
+        verify(audioManager).requestAudioFocus(
+            audioFocusListenerCaptor.capture(),
+            eq(AudioManager.STREAM_VOICE_CALL),
+            eq(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+        )
         audioDeviceSelector.stop()
-
-        verify(audioManager).abandonAudioFocus(isA())
+        audioDeviceSelector.deactivate()
+        verify(audioManager).abandonAudioFocus(audioFocusListenerCaptor.value)
     }
 
     @Test


### PR DESCRIPTION
## Description

Store a reference to onAudioFocusChangeListener that was used to request audio focus and use it with abandonAudioFocus(..) so that the framework can give back the audio focus to the previous owner.

This fix is relevant to pre Oreo devices.

## Validation
- Tested on API level 22 device

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
