### PR TITLE
Audio focus fix for pre Oreo devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.2.1
+
+Bug Fixes
+
+- Fixed a bug where the audio focus wasn't being returned to the previous audio focus owner on pre Oreo devices.
+
 ### 0.2.0
 
 Enhancements
@@ -13,7 +19,6 @@ Enhancements
 Bug Fixes
 
 - Improved the accuracy of the `BluetoothHeadset` within the `availableAudioDevices` returned from the `AudioDeviceSelector` when multiple Bluetooth Headsets are connected.
-- Fixed a bug where the audio focus wasn't being returned to the previous audio focus owner on pre Oreo devices.
 
 ### 0.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Enhancements
 Bug Fixes
 
 - Improved the accuracy of the `BluetoothHeadset` within the `availableAudioDevices` returned from the `AudioDeviceSelector` when multiple Bluetooth Headsets are connected.
+- Fixed a bug where the audio focus wasn't being returned to the previous audio focus owner on pre Oreo devices.
 
 ### 0.1.5
 

--- a/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/selection/AudioDeviceManager.kt
@@ -17,7 +17,9 @@ internal class AudioDeviceManager(
     private val logger: LogWrapper,
     private val audioManager: AudioManager,
     private val build: BuildWrapper,
-    private val audioFocusRequest: AudioFocusRequestWrapper
+    private val audioFocusRequest: AudioFocusRequestWrapper,
+    private val audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener =
+            AudioManager.OnAudioFocusChangeListener { }
 ) {
 
     private var savedAudioMode = 0
@@ -60,7 +62,7 @@ internal class AudioDeviceManager(
             audioRequest?.let { audioManager.requestAudioFocus(it) }
         } else {
             audioManager.requestAudioFocus(
-                    {},
+                    audioFocusChangeListener,
                     AudioManager.STREAM_VOICE_CALL,
                     AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
         }
@@ -100,7 +102,7 @@ internal class AudioDeviceManager(
         if (build.getVersion() >= Build.VERSION_CODES.O) {
             audioRequest?.let { audioManager.abandonAudioFocusRequest(it) }
         } else {
-            audioManager.abandonAudioFocus { }
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
         }
     }
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BaseTest.kt
@@ -5,6 +5,7 @@ import android.bluetooth.BluetoothClass
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothHeadset
 import android.content.Context
+import android.media.AudioManager
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.twilio.audioswitch.DEVICE_NAME
@@ -34,8 +35,9 @@ open class BaseTest {
     internal val audioDeviceChangeListener = mock<AudioDeviceChangeListener>()
     internal val buildWrapper = mock<BuildWrapper>()
     internal val audioFocusRequest = mock<AudioFocusRequestWrapper>()
+    internal val audioFocusChangeListener = mock<AudioManager.OnAudioFocusChangeListener>()
     internal val audioDeviceManager = AudioDeviceManager(context, logger, audioManager, buildWrapper,
-            audioFocusRequest)
+            audioFocusRequest, audioFocusChangeListener)
     internal val wiredHeadsetReceiver = WiredHeadsetReceiver(context, logger)
     internal var handler = setupScoHandlerMock()
     internal var systemClockWrapper = setupSystemClockMock()

--- a/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/selection/AudioDeviceSelectorTest.kt
@@ -254,9 +254,9 @@ class AudioDeviceSelectorTest : BaseTest() {
         audioDeviceSelector.activate()
 
         verify(audioManager).requestAudioFocus(
-                isA(),
-                eq(AudioManager.STREAM_VOICE_CALL),
-                eq(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                audioFocusChangeListener,
+                AudioManager.STREAM_VOICE_CALL,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
         )
     }
 
@@ -291,7 +291,7 @@ class AudioDeviceSelectorTest : BaseTest() {
         audioDeviceSelector.activate()
         audioDeviceSelector.stop()
 
-        verify(audioManager).abandonAudioFocus(isA())
+        verify(audioManager).abandonAudioFocus(audioFocusChangeListener)
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixed a bug where the audio focus wasn't being returned to the previous audio focus owner on pre Oreo devices.

Fixes issue #38.
Based off of original pull request by @tejas-n #39.

## Breakdown

- In `AudioDeviceManager`, Store a reference to onAudioFocusChangeListener that was used to request audio focus and use it with abandonAudioFocus(..) so that the framework can give back the audio focus to the previous owner.

## Validation

- Manually tested on a Pixel 3 and Hesh 2 Wireless and LE-Bose NC 700 HP bluetooth headsets.
- Passed CI Pipeline

## Additional Notes

Thank you @tejas-n for the contribution! Excellent work 🎉 

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
