### PR TITLE
AHOYAPPS-824: Add public audio focus change listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ val audioSwitch = AudioSwitch(context, loggingEnabled = true)
 audioSwitch.start { _, _ -> }
 ```
 
+- Added another constructor parameter that allows developers to subscribe to system audio focus changes while the library is activated.
+
+```kotlin
+val audioSwitch = AudioSwitch(context, audioFocusChangeListener = OnAudioFocusChangeListener { focusChange ->
+    // Do something with audio focus change
+))}
+
+audioSwitch.start { _, _ -> }
+// Audio focus changes are received after activating
+audioSwitch.activate()
+```
+
 ### 0.3.0
 
 Enhancements

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioFocusUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioFocusUtil.kt
@@ -1,0 +1,42 @@
+package com.twilio.audioswitch
+
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+
+class AudioFocusUtil(
+    private val audioManager: AudioManager,
+    private val audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener
+) {
+
+    private lateinit var request: AudioFocusRequest
+
+    fun requestFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val playbackAttributes = AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+            request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                    .setAudioAttributes(playbackAttributes)
+                    .setAcceptsDelayedFocusGain(true)
+                    .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                    .build()
+            audioManager.requestAudioFocus(request)
+        } else {
+            audioManager.requestAudioFocus(
+                    audioFocusChangeListener,
+                    AudioManager.STREAM_VOICE_CALL,
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+        }
+    }
+
+    fun abandonFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioManager.abandonAudioFocusRequest(request)
+        } else {
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
+        }
+    }
+}

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioSwitchIntegrationTest.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioSwitchIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.twilio.audioswitch
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
@@ -70,5 +71,16 @@ class AudioSwitchTest {
         val version: String = AudioSwitch.VERSION
         assertNotNull(version)
         assertTrue(version.matches(semVerRegex))
+    }
+
+    @Test
+    @UiThreadTest
+    fun it_should_receive_audio_focus_changes_if_configured() {
+        val audioFocusChangeLatch = CountDownLatch(1)
+//        val audioSwitch = AudioSwitch(context, audioFocusChangeListener = {
+//            audioFocusChangeLatch.countDown() })
+
+//        audioFocusChangeLatch.await()
+        TODO("Not yet implemented")
     }
 }

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioSwitchIntegrationTest.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioSwitchIntegrationTest.kt
@@ -10,9 +10,10 @@ import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
-class AudioSwitchTest {
+class AudioSwitchIntegrationTest {
 
     private val context = InstrumentationRegistry.getInstrumentation().context
 
@@ -77,10 +78,12 @@ class AudioSwitchTest {
     @UiThreadTest
     fun it_should_receive_audio_focus_changes_if_configured() {
         val audioFocusChangeLatch = CountDownLatch(1)
-//        val audioSwitch = AudioSwitch(context, audioFocusChangeListener = {
-//            audioFocusChangeLatch.countDown() })
+        val audioSwitch = AudioSwitch(context, audioFocusChangeListener = {
+            audioFocusChangeLatch.countDown()
+        })
+        audioSwitch.start { _, _ -> }
+        audioSwitch.activate()
 
-//        audioFocusChangeLatch.await()
-        TODO("Not yet implemented")
+        assertTrue(audioFocusChangeLatch.await(5, TimeUnit.SECONDS))
     }
 }

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -5,6 +5,7 @@ import android.bluetooth.BluetoothDevice
 import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
+import android.media.AudioManager.OnAudioFocusChangeListener
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.twilio.audioswitch.android.BuildWrapper
 import com.twilio.audioswitch.android.DEVICE_NAME
@@ -25,7 +26,8 @@ internal fun setupFakeAudioSwitch(context: Context):
                     logger,
                     audioManager,
                     BuildWrapper(),
-                    AudioFocusRequestWrapper())
+                    AudioFocusRequestWrapper(),
+                    OnAudioFocusChangeListener {})
     val wiredHeadsetReceiver = WiredHeadsetReceiver(context, logger)
     val headsetManager = BluetoothAdapter.getDefaultAdapter()?.let { bluetoothAdapter ->
         BluetoothHeadsetManager(context, logger, bluetoothAdapter, audioDeviceManager,
@@ -35,6 +37,7 @@ internal fun setupFakeAudioSwitch(context: Context):
     }
     return Pair(AudioSwitch(context,
         logger,
+        OnAudioFocusChangeListener {},
         audioDeviceManager,
         wiredHeadsetReceiver,
         headsetManager),

--- a/audioswitch/src/androidTest/java/com/twilio/audioswitch/manual/ConnectedBluetoothHeadsetTest.kt
+++ b/audioswitch/src/androidTest/java/com/twilio/audioswitch/manual/ConnectedBluetoothHeadsetTest.kt
@@ -1,4 +1,4 @@
-package com.twilio.audioswitch
+package com.twilio.audioswitch.manual
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothHeadset
@@ -10,6 +10,11 @@ import android.content.IntentFilter
 import android.media.AudioManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.twilio.audioswitch.AudioDevice
+import com.twilio.audioswitch.AudioSwitch
+import com.twilio.audioswitch.getInstrumentationContext
+import com.twilio.audioswitch.isSpeakerPhoneOn
+import com.twilio.audioswitch.retryAssertion
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import junit.framework.TestCase.assertEquals

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioDeviceManager.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.media.AudioDeviceInfo
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.media.AudioManager.OnAudioFocusChangeListener
 import android.os.Build
 import com.twilio.audioswitch.android.BuildWrapper
 import com.twilio.audioswitch.android.Logger
@@ -18,8 +19,7 @@ internal class AudioDeviceManager(
     private val audioManager: AudioManager,
     private val build: BuildWrapper = BuildWrapper(),
     private val audioFocusRequest: AudioFocusRequestWrapper = AudioFocusRequestWrapper(),
-    private val audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener =
-        AudioManager.OnAudioFocusChangeListener { }
+    private val audioFocusChangeListener: OnAudioFocusChangeListener
 ) {
 
     private var savedAudioMode = 0
@@ -58,7 +58,7 @@ internal class AudioDeviceManager(
     fun setAudioFocus() {
         // Request audio focus before making any device switch.
         if (build.getVersion() >= Build.VERSION_CODES.O) {
-            audioRequest = audioFocusRequest.buildRequest()
+            audioRequest = audioFocusRequest.buildRequest(audioFocusChangeListener)
             audioRequest?.let { audioManager.requestAudioFocus(it) }
         } else {
             audioManager.requestAudioFocus(

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioFocusRequestWrapper.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioFocusRequestWrapper.kt
@@ -4,11 +4,12 @@ import android.annotation.SuppressLint
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.media.AudioManager.OnAudioFocusChangeListener
 
 internal class AudioFocusRequestWrapper {
 
     @SuppressLint("NewApi")
-    fun buildRequest(): AudioFocusRequest {
+    fun buildRequest(audioFocusChangeListener: OnAudioFocusChangeListener): AudioFocusRequest {
         val playbackAttributes = AudioAttributes.Builder()
                 .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
                 .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
@@ -16,7 +17,7 @@ internal class AudioFocusRequestWrapper {
         return AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
                 .setAudioAttributes(playbackAttributes)
                 .setAcceptsDelayedFocusGain(true)
-                .setOnAudioFocusChangeListener { i: Int -> }
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
                 .build()
     }
 }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -3,6 +3,7 @@ package com.twilio.audioswitch
 import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import android.media.AudioManager
+import android.media.AudioManager.OnAudioFocusChangeListener
 import androidx.annotation.VisibleForTesting
 import com.twilio.audioswitch.AudioDevice.BluetoothHeadset
 import com.twilio.audioswitch.AudioDevice.Earpiece
@@ -104,20 +105,24 @@ class AudioSwitch {
      *
      * @param context The application context.
      * @param loggingEnabled Toggle whether logging is enabled. This argument is false by default.
+     * @param audioFocusChangeListener A listener that is invoked when the system audio focus is updated.
      */
     @JvmOverloads
-    constructor(context: Context,
-                loggingEnabled: Boolean = false,
-                audioFocusChangeListener: (() -> Unit)? = null)
-            : this(context, Logger(loggingEnabled))
+    constructor(
+        context: Context,
+        loggingEnabled: Boolean = false,
+        audioFocusChangeListener: OnAudioFocusChangeListener = OnAudioFocusChangeListener {}
+    ) : this(context, Logger(loggingEnabled), audioFocusChangeListener)
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal constructor(
         context: Context,
         logger: Logger,
+        audioFocusChangeListener: OnAudioFocusChangeListener,
         audioDeviceManager: AudioDeviceManager = AudioDeviceManager(context,
             logger,
-            context.getSystemService(Context.AUDIO_SERVICE) as AudioManager),
+            context.getSystemService(Context.AUDIO_SERVICE) as AudioManager,
+            audioFocusChangeListener = audioFocusChangeListener),
         wiredHeadsetReceiver: WiredHeadsetReceiver = WiredHeadsetReceiver(context, logger),
         headsetManager: BluetoothHeadsetManager? = BluetoothHeadsetManager.newInstance(context,
             logger,

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -105,7 +105,8 @@ class AudioSwitch {
      *
      * @param context The application context.
      * @param loggingEnabled Toggle whether logging is enabled. This argument is false by default.
-     * @param audioFocusChangeListener A listener that is invoked when the system audio focus is updated.
+     * @param audioFocusChangeListener A listener that is invoked when the system audio focus is
+     * updated. Note that updates are only sent to the listener after [activate] has been called.
      */
     @JvmOverloads
     constructor(

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -106,7 +106,10 @@ class AudioSwitch {
      * @param loggingEnabled Toggle whether logging is enabled. This argument is false by default.
      */
     @JvmOverloads
-    constructor(context: Context, loggingEnabled: Boolean = false) : this(context, Logger(loggingEnabled))
+    constructor(context: Context,
+                loggingEnabled: Boolean = false,
+                audioFocusChangeListener: (() -> Unit)? = null)
+            : this(context, Logger(loggingEnabled))
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal constructor(

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -4,7 +4,6 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +30,7 @@ public class AudioSwitchJavaTest extends BaseTest {
                 new AudioSwitch(
                         getContext$audioswitch_debug(),
                         getLogger$audioswitch_debug(),
+                        getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         getAudioDeviceManager$audioswitch_debug(),
                         getWiredHeadsetReceiver$audioswitch_debug(),
                         getHeadsetManager$audioswitch_debug());
@@ -112,11 +112,6 @@ public class AudioSwitchJavaTest extends BaseTest {
 
         assertNotNull(AudioSwitch.VERSION);
         assertTrue(AudioSwitch.VERSION.matches(semVerRegex));
-    }
-
-    @Test
-    public void shouldAllowSettingAudioFocusChangeListener() {
-        fail("Not yet implemented");
     }
 
     private void startAudioSwitch() {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -4,6 +4,7 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -111,6 +112,11 @@ public class AudioSwitchJavaTest extends BaseTest {
 
         assertNotNull(AudioSwitch.VERSION);
         assertTrue(AudioSwitch.VERSION.matches(semVerRegex));
+    }
+
+    @Test
+    public void shouldAllowSettingAudioFocusChangeListener() {
+        fail("Not yet implemented");
     }
 
     private void startAudioSwitch() {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -86,7 +86,8 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null
+            headsetManager = null,
+            audioFocusChangeListener = defaultAudioFocusChangeListener
         )
 
         audioSwitch.start(audioDeviceChangeListener)
@@ -191,7 +192,8 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null
+            headsetManager = null,
+            audioFocusChangeListener = defaultAudioFocusChangeListener
         )
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.stop()
@@ -207,7 +209,8 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null
+            headsetManager = null,
+            audioFocusChangeListener = defaultAudioFocusChangeListener
         )
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.activate()
@@ -229,7 +232,7 @@ class AudioSwitchTest : BaseTest() {
     fun `activate should set audio focus using Android O method if api version is 26`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O)
         val audioFocusRequest = mock<AudioFocusRequest>()
-        whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
+        whenever(this.audioFocusRequest.buildRequest(defaultAudioFocusChangeListener)).thenReturn(audioFocusRequest)
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.activate()
 
@@ -240,7 +243,7 @@ class AudioSwitchTest : BaseTest() {
     fun `activate should set audio focus using Android O method if api version is 27`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O_MR1)
         val audioFocusRequest = mock<AudioFocusRequest>()
-        whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
+        whenever(this.audioFocusRequest.buildRequest(defaultAudioFocusChangeListener)).thenReturn(audioFocusRequest)
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.activate()
 
@@ -254,7 +257,7 @@ class AudioSwitchTest : BaseTest() {
         audioSwitch.activate()
 
         verify(audioManager).requestAudioFocus(
-                audioFocusChangeListener,
+                defaultAudioFocusChangeListener,
                 AudioManager.STREAM_VOICE_CALL,
                 AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
         )
@@ -264,7 +267,7 @@ class AudioSwitchTest : BaseTest() {
     fun `deactivate should abandon audio focus using pre Android O method if api version is 26`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O)
         val audioFocusRequest = mock<AudioFocusRequest>()
-        whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
+        whenever(this.audioFocusRequest.buildRequest(defaultAudioFocusChangeListener)).thenReturn(audioFocusRequest)
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.activate()
         audioSwitch.stop()
@@ -276,7 +279,7 @@ class AudioSwitchTest : BaseTest() {
     fun `deactivate should abandon audio focus using pre Android O method if api version is 27`() {
         whenever(buildWrapper.getVersion()).thenReturn(Build.VERSION_CODES.O_MR1)
         val audioFocusRequest = mock<AudioFocusRequest>()
-        whenever(this.audioFocusRequest.buildRequest()).thenReturn(audioFocusRequest)
+        whenever(this.audioFocusRequest.buildRequest(defaultAudioFocusChangeListener)).thenReturn(audioFocusRequest)
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.activate()
         audioSwitch.stop()
@@ -291,7 +294,7 @@ class AudioSwitchTest : BaseTest() {
         audioSwitch.activate()
         audioSwitch.stop()
 
-        verify(audioManager).abandonAudioFocus(audioFocusChangeListener)
+        verify(audioManager).abandonAudioFocus(defaultAudioFocusChangeListener)
     }
 
     @Test
@@ -416,15 +419,5 @@ class AudioSwitchTest : BaseTest() {
                 "Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z-]+)?$")
         assertNotNull(AudioSwitch.VERSION)
         assertTrue(AudioSwitch.VERSION.matches(semVerRegex))
-    }
-
-    @Test
-    fun `setting the audioFocusChangeListener constructor parameter should receive audio focus changes`() {
-        TODO("Not yet implemented")
-    }
-
-    @Test
-    fun `not setting the audioFocusChangeListener constructor parameter should receive audio focus changes`() {
-        TODO("Not yet implemented")
     }
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -417,4 +417,14 @@ class AudioSwitchTest : BaseTest() {
         assertNotNull(AudioSwitch.VERSION)
         assertTrue(AudioSwitch.VERSION.matches(semVerRegex))
     }
+
+    @Test
+    fun `setting the audioFocusChangeListener constructor parameter should receive audio focus changes`() {
+        TODO("Not yet implemented")
+    }
+
+    @Test
+    fun `not setting the audioFocusChangeListener constructor parameter should receive audio focus changes`() {
+        TODO("Not yet implemented")
+    }
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -5,7 +5,7 @@ import android.bluetooth.BluetoothClass
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothHeadset
 import android.content.Context
-import android.media.AudioManager
+import android.media.AudioManager.OnAudioFocusChangeListener
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.twilio.audioswitch.android.BuildWrapper
@@ -28,9 +28,9 @@ open class BaseTest {
     internal val audioDeviceChangeListener = mock<AudioDeviceChangeListener>()
     internal val buildWrapper = mock<BuildWrapper>()
     internal val audioFocusRequest = mock<AudioFocusRequestWrapper>()
-    internal val audioFocusChangeListener = mock<AudioManager.OnAudioFocusChangeListener>()
+    internal val defaultAudioFocusChangeListener = mock<OnAudioFocusChangeListener>()
     internal val audioDeviceManager = AudioDeviceManager(context, logger, audioManager, buildWrapper,
-            audioFocusRequest, audioFocusChangeListener)
+            audioFocusRequest, defaultAudioFocusChangeListener)
     internal val wiredHeadsetReceiver = WiredHeadsetReceiver(context, logger)
     internal var handler = setupScoHandlerMock()
     internal var systemClockWrapper = setupSystemClockMock()
@@ -46,6 +46,7 @@ open class BaseTest {
         logger = logger,
         audioDeviceManager = audioDeviceManager,
         wiredHeadsetReceiver = wiredHeadsetReceiver,
-        headsetManager = headsetManager
+        headsetManager = headsetManager,
+        audioFocusChangeListener = defaultAudioFocusChangeListener
     )
 }


### PR DESCRIPTION
## Description

Resolves issue #53  .
Based on original PR #54 opened by @agnusin.

Added another constructor parameter that allows developers to subscribe to system audio focus changes while the library is activated.

## Validation

- Passed CI.

## Additional Notes

N/A

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
