### PR TITLE
Remove broken JVM arg from upgrade to java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ aliases:
     docker:
       - image: circleci/android:api-28-node
     environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
 
   - &integration-test-defaults
     working_directory: *workspace


### PR DESCRIPTION
## Description

The `UseContainerSupport` is now used in place of the `UseCGroupMemoryLimitForHeap` JVM argument since it is no longer supported in the latest Java 11 docker image.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
