### PR TITLE
Add internal access modifier to the SystemClockWrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.0.1
+
+Bug Fixes
+
+- Added the internal access modifier to the `SystemClockWrapper` class since it is not meant to be exposed publicly.
+
 ### 1.0.0
 
 - Promotes 0.4.0 to the first stable release of this library.

--- a/audioswitch/src/main/java/com/twilio/audioswitch/android/SystemClockWrapper.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/android/SystemClockWrapper.kt
@@ -2,7 +2,7 @@ package com.twilio.audioswitch.android
 
 import android.os.SystemClock
 
-class SystemClockWrapper {
+internal class SystemClockWrapper {
 
     fun elapsedRealtime() = SystemClock.elapsedRealtime()
 }


### PR DESCRIPTION
## Description

Added the internal access modifier to the `SystemClockWrapper` class since it is not meant to be exposed publicly. Thanks to @4brunu for finding this out as part of issue #67!

## Validation

- Passed CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
