### PR TITLE
AHOYAPPS-840: Retrieve application context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Enhancements
 
 - Upgraded Kotlin to `1.4.0`.
-- The `AudioSwitch` public constructor now retrieves the application context from the context passed in from the client.
+- The context provided when constructing `AudioSwitch` can now take any context. Previously the `ApplicationContext` was required.
 
 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Enhancements
 
 - Upgraded Kotlin to `1.4.0`.
+- The `AudioSwitch` public constructor now retrieves the application context from the context passed in from the client.
 
 Bug Fixes
 

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -103,7 +103,7 @@ class AudioSwitch {
     /**
      * Constructs a new AudioSwitch instance.
      *
-     * @param context The application context.
+     * @param context An Android Context.
      * @param loggingEnabled Toggle whether logging is enabled. This argument is false by default.
      * @param audioFocusChangeListener A listener that is invoked when the system audio focus is
      * updated. Note that updates are only sent to the listener after [activate] has been called.

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -113,7 +113,7 @@ class AudioSwitch {
         context: Context,
         loggingEnabled: Boolean = false,
         audioFocusChangeListener: OnAudioFocusChangeListener = OnAudioFocusChangeListener {}
-    ) : this(context, Logger(loggingEnabled), audioFocusChangeListener)
+    ) : this(context.applicationContext, Logger(loggingEnabled), audioFocusChangeListener)
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal constructor(


### PR DESCRIPTION
## Description

The `AudioSwitch` public constructor now retrieves the application context from the context passed in from the client.

## Validation

- Passed CI.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
