### PR TITLE
Fix typo in documentation for selectDevice

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -239,7 +239,7 @@ class AudioSwitch {
     /**
      * Selects the desired [AudioDevice]. If the provided [AudioDevice] is not
      * available, no changes are made. If the provided [AudioDevice] is null, an [AudioDevice] is
-     * chosen based on the following preference: Bluetooth, Wired Headset, Microphone, Speakerphone.
+     * chosen based on the following preference: Bluetooth, Wired Headset, Earphone, Speakerphone.
      *
      * @param audioDevice The [AudioDevice] to use
      */

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -239,7 +239,7 @@ class AudioSwitch {
     /**
      * Selects the desired [AudioDevice]. If the provided [AudioDevice] is not
      * available, no changes are made. If the provided [AudioDevice] is null, an [AudioDevice] is
-     * chosen based on the following preference: Bluetooth, Wired Headset, Earphone, Speakerphone.
+     * chosen based on the following preference: Bluetooth, Wired Headset, Earpiece, Speakerphone.
      *
      * @param audioDevice The [AudioDevice] to use
      */


### PR DESCRIPTION
## Description

Fixes a typo in the docs for `selectDevice`

## Breakdown
No new changes

## Validation

## Additional Notes

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
