### PR TITLE
VIDEO-4165: Deploy to MavenCentral

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ workflows:
 
   release:
     jobs:
-      - publish-release
+      - publish-release:
           <<: *release-filter
       - publish-docs:
           <<: *release-filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ workflows:
             branches:
               only:
                 - "master"
+                - "RCP/task/maven_central"
           requires:
             - unit-tests
             - integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
   - &signing-key
     name: Install signing key
     command: >
-      echo $SIGNING_KEY | base64 -D -o $SIGNING_SECRET_KEY_RING_FILE
+      echo $SIGNING_KEY | base64 -d >> $SIGNING_SECRET_KEY_RING_FILE
 
   - &release-filter
     filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,11 @@ aliases:
     command: >
       echo $GCP_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
 
+  - &signing-key
+    name: Install signing key
+    command: >
+      echo $SIGNING_KEY | base64 -D -o $SIGNING_SECRET_KEY_RING_FILE
+
   - &release-filter
     filters:
       tags:
@@ -126,6 +131,7 @@ jobs:
       - attach_workspace:
           at: *workspace
       - restore_cache: *restore_cache-gradle
+      - run: *signing-key
       - run:
           name: Publish AudioSwitch pre release
           command: ./gradlew -q jfrogOssSnapshotsAudioSwitchUpload
@@ -139,6 +145,7 @@ jobs:
       - attach_workspace:
           at: *workspace
       - restore_cache: *restore_cache-gradle
+      - run: *signing-key
       - run:
           name: Publish AudioSwitch release
           command: ./gradlew -q bintrayAudioSwitchReleaseUpload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,39 +180,39 @@ jobs:
       - save_cache: *save_cache-gradle
 
 workflows:
-  # build-test-publish:
-  #   jobs:
-  #     - lint
-  #     - check-format
-  #     - build-audioswitch
-  #     - unit-tests:
-  #         requires:
-  #           - build-audioswitch
-  #           - lint
-  #           - check-format
-  #     - integration-tests:
-  #         requires:
-  #           - build-audioswitch
-  #           - lint
-  #           - check-format
-  #     - publish-pre-release:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - "master"
-  #         requires:
-  #           - unit-tests
-  #           - integration-tests
+  build-test-publish:
+    jobs:
+      - lint
+      - check-format
+      - build-audioswitch
+      - unit-tests:
+          requires:
+            - build-audioswitch
+            - lint
+            - check-format
+      - integration-tests:
+          requires:
+            - build-audioswitch
+            - lint
+            - check-format
+      - publish-pre-release:
+          filters:
+            branches:
+              only:
+                - "master"
+          requires:
+            - unit-tests
+            - integration-tests
 
   release:
     jobs:
       - publish-release
-      #     <<: *release-filter
-      # - publish-docs:
-      #     <<: *release-filter
-      #     requires:
-      #       - publish-release
-      # - bump-version:
-      #     <<: *release-filter
-      #     requires:
-      #       - publish-docs
+          <<: *release-filter
+      - publish-docs:
+          <<: *release-filter
+          requires:
+            - publish-release
+      - bump-version:
+          <<: *release-filter
+          requires:
+            - publish-docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - run: *signing-key
       - run:
           name: Publish AudioSwitch release
-          command: ./gradlew -q bintrayAudioSwitchReleaseUpload
+          command: ./gradlew -q sonatypeAudioSwitchReleaseUpload
       - save_cache: *save_cache-gradle
 
   bump-version:
@@ -180,40 +180,39 @@ jobs:
       - save_cache: *save_cache-gradle
 
 workflows:
-  build-test-publish:
-    jobs:
-      - lint
-      - check-format
-      - build-audioswitch
-      - unit-tests:
-          requires:
-            - build-audioswitch
-            - lint
-            - check-format
-      # - integration-tests:
-      #     requires:
-      #       - build-audioswitch
-      #       - lint
-      #       - check-format
-      - publish-pre-release:
-          filters:
-            branches:
-              only:
-                - "master"
-                - "RCP/task/maven_central"
-          requires:
-            - unit-tests
-            # - integration-tests
+  # build-test-publish:
+  #   jobs:
+  #     - lint
+  #     - check-format
+  #     - build-audioswitch
+  #     - unit-tests:
+  #         requires:
+  #           - build-audioswitch
+  #           - lint
+  #           - check-format
+  #     - integration-tests:
+  #         requires:
+  #           - build-audioswitch
+  #           - lint
+  #           - check-format
+  #     - publish-pre-release:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - "master"
+  #         requires:
+  #           - unit-tests
+  #           - integration-tests
 
   release:
     jobs:
-      - publish-release:
-          <<: *release-filter
-      - publish-docs:
-          <<: *release-filter
-          requires:
-            - publish-release
-      - bump-version:
-          <<: *release-filter
-          requires:
-            - publish-docs
+      - publish-release
+      #     <<: *release-filter
+      # - publish-docs:
+      #     <<: *release-filter
+      #     requires:
+      #       - publish-release
+      # - bump-version:
+      #     <<: *release-filter
+      #     requires:
+      #       - publish-docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,11 +183,11 @@ workflows:
             - build-audioswitch
             - lint
             - check-format
-      - integration-tests:
-          requires:
-            - build-audioswitch
-            - lint
-            - check-format
+      # - integration-tests:
+      #     requires:
+      #       - build-audioswitch
+      #       - lint
+      #       - check-format
       - publish-pre-release:
           filters:
             branches:
@@ -196,7 +196,7 @@ workflows:
                 - "RCP/task/maven_central"
           requires:
             - unit-tests
-            - integration-tests
+            # - integration-tests
 
   release:
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Enhancements
 
 - Updated the library to use Android Gradle Plugin 4.1.1
-
+- Now published to MavenCentral
 
 ### 1.1.1
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@ Thank you to all our contributors!
 * [John Qualls](https://github.com/Alton09)
 * [Aaron Alaniz](https://github.com/aaalaniz)
 * [Tejas Nandanikar](https://github.com/tejas-n)
+* [Ryan C. Payne](https://github.com/paynerc)

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -156,4 +156,3 @@ artifactory {
     }
     clientConfig.info.setBuildNumber(getShortCommitSha())
 }
-

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -135,8 +135,7 @@ signing {
 }
 
 /*
- * The artifactory block enables publishing AudioSwitch as snapshot to
- * JFrog OSS.
+ * The artifactory block enables publishing AudioSwitch as a snapshot to JFrog OSS.
  */
 artifactory {
     contextUrl = 'https://oss.jfrog.org'

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -92,7 +92,6 @@ publishing {
             artifactId = audioSwitchArtifactId
             version = audioSwitchVersion
 
-            // Mostly self-explanatory metadata
             pom {
                 name = audioSwitchArtifactId
                 description = 'An Android audio management library for real-time communication apps.'
@@ -109,7 +108,6 @@ publishing {
                         name = 'Twilio'
                     }
                 }
-                // Version control info - if you're using GitHub, follow the format as seen here
                 scm {
                     connection = 'scm:git:github.com/twilio/audioswitch.git'
                     developerConnection = 'scm:git:ssh://github.com/twilio/audioswitch.git'

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -93,7 +93,7 @@ publishing {
             version = audioSwitchVersion
 
             pom {
-                name = audioSwitchArtifactId
+                name = 'Audioswitch'
                 description = 'An Android audio management library for real-time communication apps.'
                 url = 'https://github.com/twilio/audioswitch'
                 licenses {

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 apply plugin: "com.jfrog.artifactory"
 apply plugin: 'kotlin-android'
 apply plugin: "org.jetbrains.dokka"
@@ -76,8 +77,7 @@ def audioSwitchGroupId = 'com.twilio'
 def audioSwitchArtifactId = 'audioswitch'
 
 /*
- * The publishing and artifactory blocks enable publishing AudioSwitch as snapshot to
- * JFrog OSS.
+ * The publishing block enables publishing to both Artifactory and MavenCentral
  */
 publishing {
     publications {
@@ -92,15 +92,54 @@ publishing {
             artifactId = audioSwitchArtifactId
             version = audioSwitchVersion
 
-            pom.withXml {
-                def root = asNode()
-                root.appendNode('name', 'Audioswitch')
-                root.appendNode('url', 'https://github.com/twilio/audioswitch')
+            // Mostly self-explanatory metadata
+            pom {
+                name = audioSwitchArtifactId
+                description = 'An Android audio management library for real-time communication apps.'
+                url = 'https://github.com/twilio/audioswitch'
+                licenses {
+                    license {
+                        name = 'Apache 2.0'
+                        url = 'https://github.com/twilio/audioswitch/blob/master/LICENSE.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'Twilio'
+                        name = 'Twilio'
+                    }
+                }
+                // Version control info - if you're using GitHub, follow the format as seen here
+                scm {
+                    connection = 'scm:git:github.com/twilio/audioswitch.git'
+                    developerConnection = 'scm:git:ssh://github.com/twilio/audioswitch.git'
+                    url = 'https://github.com/twilio/audioswitch/tree/main'
+                }
+                // A slightly hacky fix so that your POM will include any transitive dependencies
+                // that your library builds upon
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
             }
         }
     }
 }
 
+signing {
+    sign publishing.publications
+}
+
+/*
+ * The artifactory block enables publishing AudioSwitch as snapshot to
+ * JFrog OSS.
+ */
 artifactory {
     contextUrl = 'https://oss.jfrog.org'
     publish {
@@ -118,22 +157,3 @@ artifactory {
     clientConfig.info.setBuildNumber(getShortCommitSha())
 }
 
-/*
- * The uploadArchives block is used to publish to Bintray
- */
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: "${mavenRepo}") {
-                authentication(
-                        userName: mavenUsername,
-                        password: mavenPassword
-                )
-            }
-            pom.version = audioSwitchVersion
-            pom.groupId = audioSwitchGroupId
-            pom.artifactId = audioSwitchArtifactId
-            pom.packaging = 'aar'
-        }
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -3,18 +3,24 @@ buildscript {
     ext.dokka_version = '1.4.10'
 
     /**
-     * Properties and environment variables needed to publish to Bintray.
+     * Properties and environment variables needed to publish.
      */
-    ext.mavenRepo = (project.hasProperty('maven.repo') ?
-            project.property("maven.repo") : '')
-    ext.mavenUsername = (project.hasProperty('maven.username') ?
-            project.property("maven.username") : '')
-    ext.mavenPassword = (project.hasProperty('maven.password') ?
-            project.property("maven.password") : '')
     ext.jfrogUsername = (project.hasProperty('jfrog.username') ?
             project.property("jfrog.username") : '')
     ext.jfrogPassword = (project.hasProperty('jfrog.password') ?
             project.property("jfrog.password") : '')
+    ext["signing.keyId"] = (project.hasProperty('signing.keyId') ?
+            project.property("signing.keyId") : '')
+    ext["signing.password"] = (project.hasProperty('signing.password') ?
+            project.property("signing.password") : '')
+    ext["signing.secretKeyRingFile"] = (project.hasProperty('signing.secretKeyRingFile') ?
+            project.property("signing.secretKeyRingFile") : '')
+    ext["ossrhUsername"] = (project.hasProperty('ossrhUsername') ?
+            project.property("ossrhUsername") : '')
+    ext["ossrhPassword"] = (project.hasProperty('ossrhPassword') ?
+            project.property("ossrhPassword") : '')
+    ext["sonatypeStagingProfileId"] = (project.hasProperty('sonatypeStagingProfileId') ?
+            project.property("sonatypeStagingProfileId") : '')
 
     ext.getPropertyValue =  { propertyKey ->
         def property  = System.getenv(propertyKey)
@@ -34,26 +40,6 @@ buildscript {
         }
 
         return property
-    }
-
-    ext.getAudioSwitchJfrogOssPassword = {
-        def audioSwitchJfrogOssPassword  = System.getenv("AUDIOSWITCH_JFROG_OSS_PASSWORD");
-
-        if (audioSwitchJfrogOssPassword == null) {
-            logger.log(LogLevel.INFO, "Could not locate AUDIOSWITCH_JFROG_OSS_PASSWORD environment variable. " +
-                    "Trying local.properties")
-            Properties properties = new Properties()
-            if (project.rootProject.file('local.properties').exists()) {
-                properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                audioSwitchJfrogOssPassword = properties.getProperty('AUDIOSWITCH_JFROG_OSS_PASSWORD')
-            }
-        }
-
-        if (audioSwitchJfrogOssPassword == null) {
-            logger.log(LogLevel.WARN, "AudioSwitch Jfrog OSS password unavailable.")
-        }
-
-        return audioSwitchJfrogOssPassword;
     }
 
     ext.getShortCommitSha = {
@@ -82,7 +68,9 @@ buildscript {
 plugins {
     id "com.diffplug.spotless" version "5.6.1"
     id "com.jfrog.artifactory" version "4.15.2"
-    id "org.jetbrains.dokka" version "1.4.10"
+    id "org.jetbrains.dokka" version "$dokka_version"
+    id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
+    id "maven-publish"
 }
 apply plugin: "com.diffplug.spotless"
 spotless {
@@ -109,6 +97,19 @@ allprojects {
         google()
         jcenter()
     }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {   //or custom repository name
+            username = ossrhUsername
+            password = ossrhPassword
+            stagingProfileId = sonatypeStagingProfileId
+        }
+    }
+
+    clientTimeout = Duration.ofSeconds(300)
+    connectTimeout = Duration.ofSeconds(60)
 }
 
 /*
@@ -230,16 +231,22 @@ task jfrogOssSnapshotsAudioSwitchUpload(type: RootGradleBuild) {
     ]
 }
 
-task bintrayAudioSwitchReleaseUpload(type: RootGradleBuild) {
+task sonatypeAudioSwitchReleaseUpload(type: RootGradleBuild) {
     description = 'Publish an AudioSwitch release'
     group = 'Publishing'
-    dependsOn validateReleaseTag
-    buildFile = file('audioswitch/build.gradle')
-    tasks = ['assembleRelease', 'uploadArchives']
+// Return this when we add the release bit below
+//    dependsOn validateReleaseTag
+    buildFile = file('build.gradle')
+    tasks = ['assembleRelease', 'publishAudioSwitchReleasePublicationToSonatypeRepository', 'closeSonatypeStagingRepository']
+// Below is what we will truly want for releasing. Uncomment when we are ready to ship!
+//    tasks = ['assembleRelease', 'publishAudioSwitchReleasePublicationToSonatypeRepository', 'closeAndReleaseSonatypeStagingRepository']
     startParameter.projectProperties += gradle.startParameter.projectProperties + [
-            'maven.repo': 'https://api.bintray.com/maven/twilio/releases/audioswitch/;publish=1',
-            'maven.username': "${getPropertyValue("AUDIOSWITCH_BINTRAY_USERNAME")}",
-            'maven.password': "${getPropertyValue("AUDIOSWITCH_BINTRAY_PASSWORD")}"
+            'signing.keyId': "${getPropertyValue("SIGNING_KEY_ID")}",
+            'signing.password' : "${getPropertyValue("SIGNING_PASSWORD")}",
+            'signing.secretKeyRingFile' : "${getPropertyValue("SIGNING_SECRET_KEY_RING_FILE")}",
+            'ossrhUsername' : "${getPropertyValue("OSSRH_USERNAME")}",
+            'ossrhPassword' : "${getPropertyValue("OSSRH_PASSWORD")}",
+            'sonatypeStagingProfileId' : "${getPropertyValue("SONATYPE_STAGING_PROFILE_ID")}"
     ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ allprojects {
 
 nexusPublishing {
     repositories {
-        sonatype {   //or custom repository name
+        sonatype {
             username = ossrhUsername
             password = ossrhPassword
             stagingProfileId = sonatypeStagingProfileId
@@ -237,12 +237,9 @@ task jfrogOssSnapshotsAudioSwitchUpload(type: RootGradleBuild) {
 task sonatypeAudioSwitchReleaseUpload(type: RootGradleBuild) {
     description = 'Publish an AudioSwitch release'
     group = 'Publishing'
-// Return this when we add the release bit below
-//    dependsOn validateReleaseTag
+    dependsOn validateReleaseTag
     buildFile = file('build.gradle')
-    tasks = ['assembleRelease', 'publishAudioSwitchReleasePublicationToSonatypeRepository', 'closeSonatypeStagingRepository']
-// Below is what we will truly want for releasing. Uncomment when we are ready to ship!
-//    tasks = ['assembleRelease', 'publishAudioSwitchReleasePublicationToSonatypeRepository', 'closeAndReleaseSonatypeStagingRepository']
+    tasks = ['assembleRelease', 'publishAudioSwitchReleasePublicationToSonatypeRepository', 'closeAndReleaseSonatypeStagingRepository']
     startParameter.projectProperties += gradle.startParameter.projectProperties + [
             'signing.keyId': "${getPropertyValue("SIGNING_KEY_ID")}",
             'signing.password' : "${getPropertyValue("SIGNING_PASSWORD")}",

--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,10 @@ task jfrogOssSnapshotsAudioSwitchUpload(type: RootGradleBuild) {
     startParameter.projectProperties += gradle.startParameter.projectProperties + [
             'preRelease': true,
             'jfrog.username': "${getPropertyValue("AUDIOSWITCH_JFROG_OSS_USERNAME")}",
-            'jfrog.password': "${getPropertyValue("AUDIOSWITCH_JFROG_OSS_PASSWORD")}"
+            'jfrog.password': "${getPropertyValue("AUDIOSWITCH_JFROG_OSS_PASSWORD")}",
+            'signing.keyId': "${getPropertyValue("SIGNING_KEY_ID")}",
+            'signing.password' : "${getPropertyValue("SIGNING_PASSWORD")}",
+            'signing.secretKeyRingFile' : "${getPropertyValue("SIGNING_SECRET_KEY_RING_FILE")}"
     ]
 }
 


### PR DESCRIPTION
## Description

This PR adds Maven Central publishing to the Audioswitch project. Previously Audioswitch was published to JCenter, but due to their pending shutdown of the service, we needed to migrate to a new artifact provider.

This PR uses the [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) to manage multitenancy and closing and releasing Next staging repositories.

A few new environment variables were added to the CircleCI settings to assist with this:

* `OSSRH_USERNAME`: The username for the MavenCentral repository. We are actually using a user token here for our `twilio-sdk-build` user.
* `OSSRH_PASSWORD`: The password for the MavenCentral repository. Again, in this case this is the user token password.
* `SONATYPE_STAGING_PROFILE_ID`: The MavenCentral staging repository profile id. This was obtained from `oss.sonatype.org`.
* `SIGNING_KEY_ID`: The signing key ID for the `twilio-sdk-build` user.
* `SIGNING_KEY`: The base64 encoded GPG private key used for signing the artifacts.
* `SIGNING_SECRET_KEY_RING_FILE`: The location where the base64 decoded GPG private key should be written during the and consumed from during the CI process.
* `SIGNING_PASSWORD`: The password for the GPG private key file

## Breakdown

- Updated the `.circleci/config.yml` file to extract the base64 encoded GPG data from the environment variable and write it to the file specified in the `SIGNING_SECRET_KEY_RING_FILE` environment variable. This is used in both the `publish-pre-release` and `publish-release` tasks.
- Updated the Gradle task name that is run in the `publish-release` task to accurately reflect what it now does: `sonatypeAudioSwitchReleaseUpload`.
- Updated `CHANGELOG.md` and `CONTRIBUTORS.md`
- Added the `signing` plugin in `audioswitch/build.gradle` and configured it for use
- Added the necessary `pom.xml` information in the `publishing: publications` block to ensure that the Maven Central requirements are met. This validation happens during the close operation on the staging repository.
- Removed the unneeded `uploadArchives` block in `audioswitch/build.gradle` now that we are no longer publishing to Bintray.
- Removed now unused gradle extended properties that were used for Bintray publishing. Also removed `ext.getAudioSwitchJfrogOssPassword` as it was not being used.
- Added both the `maven-publish` and `io.github.gradle-nexus.publish-plugin` gradle plugins to the root gradle file.
- Configured the `nexusPublishing` block for publishing to MavenCentral/Sonatype
- Added the necessary signing properties to the `jfrogOssSnapshotsAudioSwitchUpload` gradle task so that our snapshots that are published are able to be signed
- Renamed the `bintrayAudioSwitchReleaseUpload` gradle task to `sonatypeAudioSwitchReleaseUpload` to accurately reflect what it is doing.
- Augmented the `sonatypeAudioSwitchReleaseUpload` task to publish the artifacts to the Sonatype repository and then close and release it.

## Validation

- I have validated that with the changes we are still able to publish to the JFrog OSS repo. We can discuss if we want to forgo this and just publish snapshots to the MavenCentral snapshot repository. 
- I have tested the `publish-release` task to ensure that we get the artifact uploaded and the repo is closed. I have yet to actually run the portion that does the release, but from what I am seeing, it looks like it will work. Once this PR is merged, we can cut an actual release.

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
