### PR TITLE
Replace no longer supported SM-A520F FTL device

### DIFF
--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -4,7 +4,7 @@ integration-tests:
   app: audioswitch/ftl/app-debug.apk
   test: audioswitch/build/outputs/apk/androidTest/debug/audioswitch-debug-androidTest.apk
   device:
-    - {model: a5y17lte, version: 24}
+    - {model: griffin, version: 24}
     - {model: G8142, version: 25}
     - {model: c5proltechn, version: 26}
     - {model: crownqlteue, version: 27}


### PR DESCRIPTION
## Description

Replaces the SM-A520F device in firebase test lab as it is no longer supported.

## Validation

- Passes CI

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
