### PR TITLE
Update docs for MavenCentral consumption [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,17 @@ To get started using this library, follow the steps below.
 
 ### Gradle Setup
 
-[![Download](https://api.bintray.com/packages/twilio/releases/audioswitch/images/download.svg) ](https://bintray.com/twilio/releases/audioswitch/_latestVersion)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.twilio/audioswitch/badge.svg) ](https://maven-badges.herokuapp.com/maven-central/com.twilio/audioswitch)
+
+Ensure that you have `mavenCentral` listed in your project's buildscript repositories section:
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+        ...                
+    }
+}
+```
 
 Add this line as a new Gradle dependency:
 ```groovy

--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ To get started using this library, follow the steps below.
 
 ### Gradle Setup
 
-[![Download](https://api.bintray.com/packages/twilio/releases/audioswitch/images/download.svg) ](https://bintray.com/twilio/releases/audioswitch/_latestVersion)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.twilio/audioswitch/badge.svg) ](https://maven-badges.herokuapp.com/maven-central/com.twilio/audioswitch)
+
+Ensure that you have `mavenCentral` listed in your project's buildscript repositories section:
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+        ...                
+    }
+}
+```
 
 Add this line as a new Gradle dependency:
 ```groovy


### PR DESCRIPTION
## Description

Remove references to Bintray and point to MavenCentral

## Breakdown

- Updated `README.md` and `CHANGELOG.md` to refer to Maven Central instead of Bintray

## Validation

- 👀 

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
