### PR TITLE
VIDEO-4537: Move mavenCentral() above jcenter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ Ensure that you have `mavenCentral` listed in your project's buildscript reposit
 buildscript {
     repositories {
         mavenCentral()
-        ...                
+        ...
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ensure that you have `mavenCentral` listed in your project's buildscript reposit
 buildscript {
     repositories {
         mavenCentral()
-        ...                
+        ...
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
-
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
@@ -95,6 +95,7 @@ spotless {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 }


### PR DESCRIPTION
## Description

Move mavenCentral() above jcenter() in the project level build.gradle repositories block. Also fixed some formatting.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
