### PR TITLE
VIDEO-7662: Publish snapshots to MavenCentral

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
 version: 2.1
 
+parameters:
+  # this flag allows you to disable the default workflow, e.g. when running the standalone publish-snapshot workflow
+  enable-default-workflow:
+    description: "enables the main workflow that builds and tests on all branches and publishes a snapshot on master"
+    type: boolean
+    default: true
+
+  # this flag allows you to publish a snapshot from any branch, using a standalone workflow
+  enable-publish-snapshot-workflow:
+    description: "enables the standalone workflow to build and publish a snapshot from any branch"
+    type: boolean
+    default: false
+
 aliases:
   - &workspace
       ~/audioswitch
@@ -14,6 +27,12 @@ aliases:
           - /^\d+\.\d+\.\d+$/
       branches:
         ignore: /.*/
+
+  - &snapshot-filter
+    filters:
+      branches:
+        only:
+          - master
 
 commands:
   restore_gradle_cache:
@@ -65,9 +84,8 @@ commands:
       - run:
           name: Publish AudioSwitch <<# parameters.pre-release >> snapshot <</ parameters.pre-release >><<^ parameters.pre-release >> release <</ parameters.pre-release >>
           command: |
-            ./gradlew sonatypeAudioSwitchReleaseUpload \
+            ./gradlew -q sonatypeAudioSwitchReleaseUpload \
             -PpreRelease=<< parameters.pre-release >>
-
 
 executors:
   build-executor:
@@ -145,7 +163,7 @@ jobs:
           at: *workspace
       - setup_gcloud
       - run:
-          name: Integration Tests
+          name: Run Integration Tests
           command: >
             gcloud firebase test android run --use-orchestrator --environment-variables clearPackageData=true --no-record-video --project video-app-79418
             ui-test-args.yaml:integration-tests
@@ -201,7 +219,9 @@ jobs:
       - save_gradle_cache
 
 workflows:
+  # default workflow, runs check and tests on all branches and publishes a snapshot on master
   build-test-publish:
+    when: << pipeline.parameters.enable-default-workflow >>
     jobs:
       - lint
       - check-format
@@ -217,15 +237,12 @@ workflows:
             - lint
             - check-format
       - publish-pre-release:
-          filters:
-            branches:
-              only:
-                - master
-                - task/VIDEO-7662-mavencental-snapshots
+          <<: *snapshot-filter
           requires:
             - unit-tests
             - integration-tests
 
+  # workflow to publish a release, triggered by new git tags that match a version number, e.g. '1.2.3'
   release:
     jobs:
       - publish-release:
@@ -238,3 +255,9 @@ workflows:
           <<: *release-filter
           requires:
             - publish-docs
+
+  # workflow to explicitly build and publish a snapshot from any branch
+  publish-snapshot:
+    when: << pipeline.parameters.enable-publish-snapshot-workflow >>
+    jobs:
+      - publish-pre-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ executors:
   build-executor:
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-31
+      - image: circleci/android:api-30
     resource_class: large
     environment:
       _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - save_gradle_cache
 
 workflows:
-  # default workflow, runs check and tests on all branches and publishes a snapshot on master
+  # Default workflow. Triggered by all commits. Runs checks and tests on all branches. For master, also publishes a snapshot.
   build-test-publish:
     when: << pipeline.parameters.enable-default-workflow >>
     jobs:
@@ -242,7 +242,7 @@ workflows:
             - unit-tests
             - integration-tests
 
-  # workflow to publish a release, triggered by new git tags that match a version number, e.g. '1.2.3'
+  # Workflow to publish a release. Triggered by new git tags that match a version number, e.g. '1.2.3'.
   release:
     jobs:
       - publish-release:
@@ -256,7 +256,7 @@ workflows:
           requires:
             - publish-docs
 
-  # workflow to explicitly build and publish a snapshot from any branch
+  # Workflow to explicitly build and publish a snapshot. Triggered manually by setting the parameter to true.
   publish-snapshot:
     when: << pipeline.parameters.enable-publish-snapshot-workflow >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,46 +5,7 @@ aliases:
       ~/audioswitch
 
   - &gradle-cache-key
-    key: jars-{{ checksum "build.gradle" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-  - &restore_cache-gradle
-    <<: *gradle-cache-key
-    name: Restore Gradle Cache
-  - &save_cache-gradle
-    <<: *gradle-cache-key
-    name: Save Gradle Cache
-    paths:
-      - ~/.gradle/caches
-      - ~/.gradle/wrapper
-
-  - &configure-git-user
-    name: Configure git user
-    command: |
-      git config --global user.email $GIT_USER_EMAIL
-      git config --global user.name $GIT_USER_NAME
-
-  - &build-defaults
-    working_directory: *workspace
-    docker:
-      - image: circleci/android:api-28-node
-    environment:
-      - _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
-
-  - &integration-test-defaults
-    working_directory: *workspace
-    docker:
-      - image: google/cloud-sdk:latest
-    environment:
-    resource_class: medium+
-
-  - &gcloud-auth
-    name: Google Cloud Auth
-    command: >
-      echo $GCP_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
-
-  - &signing-key
-    name: Install signing key
-    command: >
-      echo $SIGNING_KEY | base64 -d >> $SIGNING_SECRET_KEY_RING_FILE
+      jars-{{ checksum "build.gradle" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
   - &release-filter
     filters:
@@ -54,40 +15,107 @@ aliases:
       branches:
         ignore: /.*/
 
+commands:
+  restore_gradle_cache:
+    steps:
+      - restore_cache:
+          key: *gradle-cache-key
+          name: Restore Gradle Cache
+
+  save_gradle_cache:
+    steps:
+      - save_cache:
+          key: *gradle-cache-key
+          name: Save Gradle Cache
+          paths:
+            - ~/.gradle/caches
+            - ~/.gradle/wrapper
+
+  setup_git_user:
+    description: Configure git user
+    steps:
+      - run:
+          name: Configure git user name and email
+          command: |
+            git config --global user.email $GIT_USER_EMAIL
+            git config --global user.name $GIT_USER_NAME
+
+  setup_gcloud:
+    description: Authenticate with Google Cloud
+    steps:
+      - run:
+          name: Setup GCloud Auth
+          command: |
+            echo $GCP_KEY | base64 -d | gcloud auth activate-service-account --key-file=-
+
+  install_signing_key:
+    steps:
+      - run:
+          name: Install signing key
+          command: |
+            echo $SIGNING_KEY | base64 -d >> $SIGNING_SECRET_KEY_RING_FILE
+
+  publish_to_sonatype:
+    description: Publish to Sonatype Repository
+    parameters:
+      pre-release:
+        description: If true, publish a pre-release, otherwise publish a release
+        type: boolean
+    steps:
+      - run:
+          name: Publish AudioSwitch <<# parameters.pre-release >> snapshot <</ parameters.pre-release >><<^ parameters.pre-release >> release <</ parameters.pre-release >>
+          command: |
+            ./gradlew sonatypeAudioSwitchReleaseUpload \
+            -PpreRelease=<< parameters.pre-release >>
+
+
+executors:
+  build-executor:
+    working_directory: *workspace
+    docker:
+      - image: circleci/android:api-31
+    resource_class: large
+    environment:
+      _JAVA_OPTIONS: "-XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport"
+
+  integration-test-executor:
+    working_directory: *workspace
+    docker:
+      - image: google/cloud-sdk:latest
+    resource_class: medium+
+
 jobs:
   lint:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
-      - restore_cache: *restore_cache-gradle
+      - restore_gradle_cache
       - run:
           name: Lint
           command: ./gradlew -q lint
       - store_artifacts:
           path: audioswitch/build/reports/lint-results.html
-          prefix: audioswitch
-      - save_cache: *save_cache-gradle
+          destination: audioswitch
+      - save_gradle_cache
 
   check-format:
-    <<: *build-defaults
+    executor: build-executor
     resource_class: medium+
     steps:
       - checkout
-      - restore_cache: *restore_cache-gradle
+      - restore_gradle_cache
       - run:
           name: Spotless Check
           command: ./gradlew -q spotlessCheck
-      - save_cache: *save_cache-gradle
+      - save_gradle_cache
 
   build-audioswitch:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore_cache: *restore_cache-gradle
+      - restore_gradle_cache
       - run:
           name: Build AudioSwitch and Tests
           command: ./gradlew -q audioswitch:assemble audioswitch:assembleAndroidTest
@@ -95,28 +123,27 @@ jobs:
           root: .
           paths:
             - audioswitch/build
-      - save_cache: *save_cache-gradle
+      - save_gradle_cache
 
   unit-tests:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore_cache: *restore_cache-gradle
+      - restore_gradle_cache
       - run:
           name: Unit Tests
           command: ./gradlew audioswitch:testDebugUnitTest
-      - save_cache: *save_cache-gradle
+      - save_gradle_cache
 
   integration-tests:
-    <<: *integration-test-defaults
+    executor: integration-test-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - run: *gcloud-auth
+      - setup_gcloud
       - run:
           name: Integration Tests
           command: >
@@ -124,60 +151,54 @@ jobs:
             ui-test-args.yaml:integration-tests
 
   publish-pre-release:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore_cache: *restore_cache-gradle
-      - run: *signing-key
-      - run:
-          name: Publish AudioSwitch pre release
-          command: ./gradlew -q jfrogOssSnapshotsAudioSwitchUpload
-      - save_cache: *save_cache-gradle
+      - restore_gradle_cache
+      - install_signing_key
+      - publish_to_sonatype:
+          pre-release: true
+      - save_gradle_cache
 
   publish-release:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore_cache: *restore_cache-gradle
-      - run: *signing-key
-      - run:
-          name: Publish AudioSwitch release
-          command: ./gradlew -q sonatypeAudioSwitchReleaseUpload
-      - save_cache: *save_cache-gradle
+      - restore_gradle_cache
+      - install_signing_key
+      - publish_to_sonatype:
+          pre-release: false
+      - save_gradle_cache
 
   bump-version:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore_cache: *restore_cache-gradle
-      - run: *configure-git-user
+      - restore_gradle_cache
+      - setup_git_user
       - run:
           name: Bump Version
           command: ./gradlew incrementVersion
-      - save_cache: *save_cache-gradle
+      - save_gradle_cache
 
   publish-docs:
-    <<: *build-defaults
-    resource_class: large
+    executor: build-executor
     steps:
       - checkout
       - attach_workspace:
           at: *workspace
-      - restore_cache: *restore_cache-gradle
-      - run: *configure-git-user
+      - restore_gradle_cache
+      - setup_git_user
       - run:
           name: Publish Docs
           command: ./gradlew publishDocs
-      - save_cache: *save_cache-gradle
+      - save_gradle_cache
 
 workflows:
   build-test-publish:
@@ -199,7 +220,8 @@ workflows:
           filters:
             branches:
               only:
-                - "master"
+                - master
+                - task/VIDEO-7662-mavencental-snapshots
           requires:
             - unit-tests
             - integration-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ### 1.1.3
 
 Enhancements
@@ -7,6 +8,7 @@ Enhancements
 - Updated internal dependencies related to Android 12 support
 - Updated compile and target sdk to Android 12 (31)
 - Updated gradle to version 4.2.1
+- Snapshots are now published to the Maven Central snapshots repository
 
 ### 1.1.2
 
@@ -65,7 +67,7 @@ audioSwitch.start { _, _ -> }
 ```kotlin
 val audioSwitch = AudioSwitch(context, audioFocusChangeListener = OnAudioFocusChangeListener { focusChange ->
     // Do something with audio focus change
-))}
+})
 
 audioSwitch.start { _, _ -> }
 // Audio focus changes are received after activating
@@ -170,7 +172,7 @@ Ensure that you have `mavenCentral` listed in your project's buildscript reposit
 buildscript {
     repositories {
         mavenCentral()
-        ...
+        // ...
     }
 }
 ```

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ Thank you to all our contributors!
 * [Tejas Nandanikar](https://github.com/tejas-n)
 * [Ryan C. Payne](https://github.com/paynerc)
 * [Ardavon Falls](https://github.com/afalls-twilio)
+* [Magnus Martikainen](https://github.com/mmartikainen)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ensure that you have `mavenCentral` listed in your project's buildscript reposit
 buildscript {
     repositories {
         mavenCentral()
-        ...
+        // ...
     }
 }
 ```
@@ -47,14 +47,21 @@ Add this line as a new Gradle dependency:
 implementation 'com.twilio:audioswitch:$version'
 ```
 
-Pull requests merged to master result in an artifact being published to [JFrog OSS Snapshots](https://oss.jfrog.org/artifactory/webapp/#/home). You can
-access these snapshots by adding the following to your gradle file.
+Pull requests merged to master result in a snapshot artifact being published to the Maven Central snapshots repository. You can
+access these snapshots by adding the following to your gradle file `repositories`:
 
 ```groovy
 maven {
-    url 'https://oss.jfrog.org/artifactory/libs-snapshot/'
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+    mavenContent {
+        snapshotsOnly()
+    }
 }
+```
 
+Add a `-SNAPSHOT` suffix to the Gradle dependency version:
+
+```groovy
 implementation 'com.twilio:audioswitch:$version-SNAPSHOT'
 ```
 

--- a/audioswitch/build.gradle
+++ b/audioswitch/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: "com.jfrog.artifactory"
 apply plugin: 'kotlin-android'
 apply plugin: "org.jetbrains.dokka"
 
@@ -78,7 +77,7 @@ def audioSwitchGroupId = 'com.twilio'
 def audioSwitchArtifactId = 'audioswitch'
 
 /*
- * The publishing block enables publishing to both Artifactory and MavenCentral
+ * The publishing block enables publishing to MavenCentral
  */
 publishing {
     publications {
@@ -133,24 +132,4 @@ publishing {
 
 signing {
     sign publishing.publications
-}
-
-/*
- * The artifactory block enables publishing AudioSwitch as a snapshot to JFrog OSS.
- */
-artifactory {
-    contextUrl = 'https://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = jfrogUsername
-            password = jfrogPassword
-        }
-        defaults {
-            publications('audioSwitchRelease')
-            publishArtifacts = true
-            publishPom = true
-        }
-    }
-    clientConfig.info.setBuildNumber(getShortCommitSha())
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,15 +48,13 @@ buildscript {
         if(gitSha != null) return gitSha.substring(0, 7) else return ""
     }
 
+    ext.isPreRelease = (project.hasProperty("preRelease") && project.property("preRelease").toBoolean() == true)
     ext.audioSwitchVersion = "${versionMajor}.${versionMinor}.${versionPatch}" +
-            ((project.hasProperty("preRelease") && project.property("preRelease").toBoolean() == true) ?
-                    "-SNAPSHOT" :
-                    '')
+            (isPreRelease ? "-SNAPSHOT" : '')
 
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -67,7 +65,6 @@ buildscript {
 
 plugins {
     id "com.diffplug.spotless" version "5.6.1"
-    id "com.jfrog.artifactory" version "4.15.2"
     id "org.jetbrains.dokka" version "$dokka_version"
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
     id "maven-publish"
@@ -96,7 +93,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 
@@ -106,6 +102,7 @@ nexusPublishing {
             username = ossrhUsername
             password = ossrhPassword
             stagingProfileId = sonatypeStagingProfileId
+            useStaging = !isPreRelease
         }
     }
 
@@ -148,7 +145,7 @@ task validateReleaseTag {
 
     doLast {
         def circleTag = System.getenv("CIRCLE_TAG")
-        def tagsMatch = (matchesVersion(circleTag)) ? ("true") : ("false")
+        def tagsMatch = (matchesVersion(circleTag) || isPreRelease) ? ("true") : ("false")
 
         exec {
             workingDir "${rootDir}"
@@ -220,23 +217,8 @@ task incrementVersion(type: RootGradleBuild) {
     }
 }
 
-task jfrogOssSnapshotsAudioSwitchUpload(type: RootGradleBuild) {
-    description = 'Publish an AudioSwitch Snapshot to JFrog OSS'
-    group = 'Publishing'
-    buildFile = file('audioswitch/build.gradle')
-    tasks = ['assembleRelease', 'artifactoryPublish']
-    startParameter.projectProperties += gradle.startParameter.projectProperties + [
-            'preRelease': true,
-            'jfrog.username': "${getPropertyValue("AUDIOSWITCH_JFROG_OSS_USERNAME")}",
-            'jfrog.password': "${getPropertyValue("AUDIOSWITCH_JFROG_OSS_PASSWORD")}",
-            'signing.keyId': "${getPropertyValue("SIGNING_KEY_ID")}",
-            'signing.password' : "${getPropertyValue("SIGNING_PASSWORD")}",
-            'signing.secretKeyRingFile' : "${getPropertyValue("SIGNING_SECRET_KEY_RING_FILE")}"
-    ]
-}
-
 task sonatypeAudioSwitchReleaseUpload(type: RootGradleBuild) {
-    description = 'Publish an AudioSwitch release'
+    description = 'Publish an AudioSwitch release or pre-release'
     group = 'Publishing'
     dependsOn validateReleaseTag
     buildFile = file('build.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 versionMajor=1
 versionMinor=1
-versionPatch=4
+versionPatch=3


### PR DESCRIPTION
## Description

JFrog no longer supports publication of snapshots. This PR provides the changes needed to publish audioswitch snapshots to MavenCentral instead. I also took the opportunity to refactor the Circle CI configuration a bit.

## Breakdown

Gradle changes:
- remove references to artifactory
- publish snapshots to maven central snapshots repository
- remove obsolete `jcenter` from repositories

Circle CI changes:
- refactor Circle CI config file to use commands and executors
- add parameter for pre-release publishing to maven central
- add parameter for disabling default CI workflow 
- add parameter and workflow for publishing a snapshot from any branch
- add comments and do other minor refactoring in CI config

Other changes:
- restore patch version number to 3, since that is the next version to be published
- update README with info on how to reference maven central snapshots
- add CHANGELOG entry
- add contributor

 
## Validation

- Built locally
- CI builds are green
- Published a snapshot and validated that it can be consumed by following instructions in the readme

## Additional Notes

I did not explicitly validate that publishing a release works as expected, however that will happen after this PR has been merged.

## Submission Checklist
 - [x] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [x] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
