### PR TITLE
Update README: remove snapshotsOnly from snapshots instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ access these snapshots by adding the following to your gradle file `repositories
 ```groovy
 maven {
     url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-    mavenContent {
-        snapshotsOnly()
-    }
 }
 ```
 


### PR DESCRIPTION
## Description

Adding the Maven Central snapshots repository with `snapshotsOnly` restriction causes releases not to be located correctly. Removing this restriction fixes that problem. 

## Breakdown

- remove snapshotsOnly from maven repository spec

## Validation

- tried it with a release and a snapshot and validated that both work

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
