### PR TITLE
VIDEO-7698 dokka upgraded so docs can be generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.1.4
+- Dokka dependency upgraded such that documents can be generated successfully again.
+
 ### 1.1.3
 
 Enhancements

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.4.21'
-    ext.dokka_version = '1.4.10'
+    ext.dokka_version = '1.4.32'
 
     /**
      * Properties and environment variables needed to publish.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 versionMajor=1
 versionMinor=1
-versionPatch=3
+versionPatch=4


### PR DESCRIPTION
## Description

Upgraded Dokka dependency so that the docs can be generated again.

## Breakdown

Updated dokka version to 1.4.32

## Validation

Was able to build documentation.

## Additional Notes

none

## Submission Checklist
 - [*] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [*] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
