### PR TITLE
VIDEO-7850 Spurious events and Invalid State Exception issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 Enhancements
 
 - Dokka dependency upgraded such that documents can be generated successfully again.
-- Fixed issue with spurious AudioDeviceChangedListener invocations.
-- Fixed issue where InvalidStateException would be triggered if audioswitch.stop(..) was called after granting bluetooth permissions (after audioswitch.start(..)).
+
+Bug Fixes
+
+- Fixed issue with spurious `AudioDeviceChangedListener` invocations.
+- Fixed issue where `InvalidStateException` would be triggered durring `audioswitch.stop(..)` if bluetooth permissions were granted after 'AudioSwitch.start()`.
 
 ### 1.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ### 1.1.4
+
+Enhancements
+
 - Dokka dependency upgraded such that documents can be generated successfully again.
+- Fixed issue with spurious AudioDeviceChangedListener invocations.
+- Fixed issue where InvalidStateException would be triggered if audioswitch.stop(..) was called after granting bluetooth permissions (after audioswitch.start(..)).
 
 ### 1.1.3
 

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -49,6 +49,7 @@ class AudioSwitch {
     internal enum class State {
         STARTED, ACTIVATED, STOPPED
     }
+
     internal val bluetoothDeviceConnectionListener = object : BluetoothHeadsetConnectionListener {
         override fun onBluetoothHeadsetStateChanged(headsetName: String?) {
             enumerateDevices(headsetName)
@@ -261,7 +262,15 @@ class AudioSwitch {
         }
     }
 
+    internal data class AudioDeviceState(
+        val audioDeviceList: List<AudioDevice>,
+        val selectedAudioDevice: AudioDevice?) {
+    }
+
     private fun enumerateDevices(bluetoothHeadsetName: String? = null) {
+        // save off the old state and 'semi'-deep copy the list of audio devices
+        val oldAudioDeviceState = AudioDeviceState(mutableAudioDevices.map { it } , selectedDevice)
+        // update audio device list and selected device
         addAvailableAudioDevices(bluetoothHeadsetName)
 
         if (!userSelectedDevicePresent(mutableAudioDevices)) {
@@ -292,13 +301,17 @@ class AudioSwitch {
         if (state == ACTIVATED) {
             activate()
         }
-        audioDeviceChangeListener?.let { listener ->
-            selectedDevice?.let { selectedDevice ->
-                listener.invoke(
+        // trigger audio device change listener if there has been a change
+        val newAudioDeviceState = AudioDeviceState(mutableAudioDevices, selectedDevice)
+        if (newAudioDeviceState != oldAudioDeviceState) {
+            audioDeviceChangeListener?.let { listener ->
+                selectedDevice?.let { selectedDevice ->
+                    listener.invoke(
                         mutableAudioDevices,
                         selectedDevice)
-            } ?: run {
-                listener.invoke(mutableAudioDevices, null)
+                } ?: run {
+                    listener.invoke(mutableAudioDevices, null)
+                }
             }
         }
     }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -264,12 +264,12 @@ class AudioSwitch {
 
     internal data class AudioDeviceState(
         val audioDeviceList: List<AudioDevice>,
-        val selectedAudioDevice: AudioDevice?) {
-    }
+        val selectedAudioDevice: AudioDevice?
+    )
 
     private fun enumerateDevices(bluetoothHeadsetName: String? = null) {
         // save off the old state and 'semi'-deep copy the list of audio devices
-        val oldAudioDeviceState = AudioDeviceState(mutableAudioDevices.map { it } , selectedDevice)
+        val oldAudioDeviceState = AudioDeviceState(mutableAudioDevices.map { it }, selectedDevice)
         // update audio device list and selected device
         addAvailableAudioDevices(bluetoothHeadsetName)
 

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
@@ -170,7 +170,10 @@ internal constructor(
         if (hasPermissions()) {
             headsetListener = null
             bluetoothAdapter.closeProfileProxy(BluetoothProfile.HEADSET, headsetProxy)
-            context.unregisterReceiver(this)
+            // because start may have been called before bluetooth permissions were enabled
+            try {
+                context.unregisterReceiver(this)
+            } catch (_: IllegalArgumentException) { /* silently fall though */ }
         } else {
             logger.w(TAG, PERMISSION_ERROR_MESSAGE)
         }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -611,13 +611,13 @@ class AudioSwitchTest : BaseTest() {
     }
     @Test
     fun `Upon receiving redundant system events, redundant onAudioChanged events shall not be triggered`() {
-        audioSwitch.start (audioDeviceChangeListener)
+        audioSwitch.start(audioDeviceChangeListener)
         simulateNewBluetoothHeadsetConnection()
         audioSwitch.activate()
         // additional disconnects should not invoke the listener, after the first disconnect,
         // device list and selected device should not change
-        simulateDisconnectedBluetoothHeadsetConnection();
-        simulateDisconnectedBluetoothHeadsetConnection();
+        simulateDisconnectedBluetoothHeadsetConnection()
+        simulateDisconnectedBluetoothHeadsetConnection()
         verify(audioDeviceChangeListener, times(2)).invoke(
             listOf(Earpiece(), Speakerphone()), Earpiece())
     }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -609,6 +609,18 @@ class AudioSwitchTest : BaseTest() {
                     equalTo(true))
         }
     }
+    @Test
+    fun `Upon receiving redundant system events, redundant onAudioChanged events shall not be triggered`() {
+        audioSwitch.start (audioDeviceChangeListener)
+        simulateNewBluetoothHeadsetConnection()
+        audioSwitch.activate()
+        // additional disconnects should not invoke the listener, after the first disconnect,
+        // device list and selected device should not change
+        simulateDisconnectedBluetoothHeadsetConnection();
+        simulateDisconnectedBluetoothHeadsetConnection();
+        verify(audioDeviceChangeListener, times(2)).invoke(
+            listOf(Earpiece(), Speakerphone()), Earpiece())
+    }
 
     private fun simulateNewWiredHeadsetConnection() {
         val intent = mock<Intent> {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -84,4 +84,17 @@ open class BaseTest {
         }
         headsetManager.onReceive(context, intent)
     }
+
+    internal fun simulateDisconnectedBluetoothHeadsetConnection(
+        bluetoothDevice: BluetoothDevice = expectedBluetoothDevice
+    ) {
+        val intent = mock<Intent> {
+            whenever(mock.action).thenReturn(BluetoothHeadset.ACTION_AUDIO_STATE_CHANGED)
+            whenever(mock.getIntExtra(BluetoothHeadset.EXTRA_STATE, BluetoothHeadset.STATE_DISCONNECTED))
+                .thenReturn(BluetoothHeadset.STATE_DISCONNECTED)
+            whenever(mock.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE))
+                .thenReturn(bluetoothDevice)
+        }
+        headsetManager.onReceive(context, intent)
+    }
 }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
@@ -99,6 +99,8 @@ class BluetoothHeadsetManagerTest : BaseTest() {
 
     @Test
     fun `stop should close close all resources`() {
+        val deviceListener = mock<BluetoothHeadsetConnectionListener>()
+        headsetManager.start(deviceListener);
         headsetManager.stop()
 
         assertBluetoothHeadsetTeardown()

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
@@ -100,7 +100,7 @@ class BluetoothHeadsetManagerTest : BaseTest() {
     @Test
     fun `stop should close close all resources`() {
         val deviceListener = mock<BluetoothHeadsetConnectionListener>()
-        headsetManager.start(deviceListener);
+        headsetManager.start(deviceListener)
         headsetManager.stop()
 
         assertBluetoothHeadsetTeardown()


### PR DESCRIPTION
## Description
Fixed two issues, one is caused when Bluetooth permissions are granted after audioswitch has been started and audio switch is subsequently stopped. The other issue has existed for some time and is the result of devices sending multiple disconnect events.

## Breakdown

- Fixed issue where InvalidStateException on audioswitch.stop(..) was being thrown when the bluetooth subsystem was not registered due to lack of permissions.
- Fixed issue where spurious audioDeviceChanged events were being sent as a reaction to spurious events from system.
- Added test case to test spurious audioDeviceChanged events

## Validation

- Tested both use-cases outlined by customer
- Added unit test case for spurious events

## Additional Notes

None

## Submission Checklist
 - [*] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [*] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
