### PR TITLE
Fix issue #119 by ensuring the existing runnable is cancelled

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothScoJob.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothScoJob.kt
@@ -24,6 +24,9 @@ internal abstract class BluetoothScoJob(
     open fun scoTimeOutAction() {}
 
     fun executeBluetoothScoJob() {
+        // cancel existing runnable
+        bluetoothScoRunnable?.let { bluetoothScoHandler.removeCallbacks(it) }
+
         BluetoothScoRunnable().apply {
             bluetoothScoRunnable = this
             bluetoothScoHandler.post(this)


### PR DESCRIPTION
## Description

As seen in https://github.com/twilio/audioswitch/issues/119

When switching away from a Bluetooth headset to the speaker (for example), then switching back to the Bluetooth headset, a few seconds later the audio will be switched back to the "earpiece".

After debugging this, I found that this happens because there are multiple `EnableBluetoothScoJob` runnables running, with one of them timing out, therefore causing the `AudioActivationError` state to be set and causing the behaviour of the connection having errored, although this isn't the case and audio is still heard through the BT headset.

This fixes the problem by ensuring that when we start a new `EnableBluetoothScoJob`, we cancel the existing runnable first (if it exists).

## Breakdown

- Added call to `Handler::removeCallbacks` within the `BluetoothScoJob::executeBluetoothScoJob` ensuring only one runnable is running.

## Validation

- Tested on a minimal sample app, switching between audio devices in a call, including powering off/on my BT headset at intervals. Working exactly as intended now.

## Additional Notes

n/a

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
