### PR TITLE
Bug/video 12475/bluetooth integration tests

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
@@ -38,6 +38,7 @@ private const val TAG = "BluetoothHeadsetManager"
 private const val PERMISSION_ERROR_MESSAGE = "Bluetooth unsupported, permissions not granted"
 
 internal class BluetoothHeadsetManager
+
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal constructor(
     private val context: Context,

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
@@ -38,7 +38,6 @@ private const val TAG = "BluetoothHeadsetManager"
 private const val PERMISSION_ERROR_MESSAGE = "Bluetooth unsupported, permissions not granted"
 
 internal class BluetoothHeadsetManager
-
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal constructor(
     private val context: Context,
@@ -356,19 +355,21 @@ internal constructor(
         PermissionsCheckStrategy {
         @SuppressLint("NewApi")
         override fun hasPermissions(): Boolean {
-            return when (context.applicationInfo.targetSdkVersion) {
-                in android.os.Build.VERSION_CODES.BASE..android.os.Build.VERSION_CODES.R -> {
-                    PERMISSION_GRANTED == context.checkPermission(
-                        Manifest.permission.BLUETOOTH,
-                        android.os.Process.myPid(),
-                        android.os.Process.myUid())
-                } else -> {
-                    // for android 12/S or newer
-                    PERMISSION_GRANTED == context.checkPermission(
-                        Manifest.permission.BLUETOOTH_CONNECT,
-                        android.os.Process.myPid(),
-                        android.os.Process.myUid())
-                }
+            return if (context.applicationInfo.targetSdkVersion <= android.os.Build.VERSION_CODES.R
+                || android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.R
+            ) {
+                PERMISSION_GRANTED == context.checkPermission(
+                    Manifest.permission.BLUETOOTH,
+                    android.os.Process.myPid(),
+                    android.os.Process.myUid()
+                )
+            } else {
+                // for android 12/S or newer
+                PERMISSION_GRANTED == context.checkPermission(
+                    Manifest.permission.BLUETOOTH_CONNECT,
+                    android.os.Process.myPid(),
+                    android.os.Process.myUid()
+                )
             }
         }
     }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
@@ -355,8 +355,8 @@ internal constructor(
         PermissionsCheckStrategy {
         @SuppressLint("NewApi")
         override fun hasPermissions(): Boolean {
-            return if (context.applicationInfo.targetSdkVersion <= android.os.Build.VERSION_CODES.R
-                || android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.R
+            return if (context.applicationInfo.targetSdkVersion <= android.os.Build.VERSION_CODES.R ||
+                android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.R
             ) {
                 PERMISSION_GRANTED == context.checkPermission(
                     Manifest.permission.BLUETOOTH,

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -5,8 +5,8 @@ integration-tests:
   test: audioswitch/build/outputs/apk/androidTest/debug/audioswitch-debug-androidTest.apk
   device:
     - {model: griffin, version: 24}
-    - {model: G8441, version: 26}
-    - {model: heroqltetfnvzw, version: 26}
-    - {model: j7popltevzw, version: 27}
+    - {model: starqlteue, version: 26}
+    - {model: crownqlteue, version: 29}
+    - {model: cactus, version: 27}
     - {model: oriole, version: 31}
     - {model: redfin, version: 30}


### PR DESCRIPTION
## Description
In a scenario where targetSdkVersion > 30 and device sdk version <= 30 bluetooth permission check would look into incorrect permission for the device and thus return false which in return would fail to initialise bluetooth capabilities.
[Description of the Pull Request]

## Breakdown

- Adding or for devices under 30 api level in bluetooth permission check
- Update FTL device list

## Validation

- [CI link](https://app.circleci.com/pipelines/github/twilio/audioswitch/528/workflows/55728c21-737d-43c4-9191-07015aaacedd)
- Manually check that when targetSdkVersion <= 30 and device SDK > 30 is selecting bluetooth headset and theres audio flow
- Manually check that when targetSdkVersion > 30 and device SDK <= 30 is selecting bluetooth headset and theres audio flow

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
