### PR TITLE
Enumerate devices first before starting connection listeners

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -157,9 +157,9 @@ class AudioSwitch {
         audioDeviceChangeListener = listener
         when (state) {
             STOPPED -> {
+                enumerateDevices()
                 bluetoothHeadsetManager?.start(bluetoothDeviceConnectionListener)
                 wiredHeadsetReceiver.start(wiredDeviceConnectionListener)
-                enumerateDevices()
                 state = STARTED
             }
             else -> {


### PR DESCRIPTION
## Description
`enumerateDevices()` method call from wired and bluetooth connection receivers could overlap with `enumerateDevices()` call when AudioSwitch is started. This lead to two potential issues, especially when AudioSwitch was stoped and then restarted:
 - ConcurrentModificationException for the device list
 - Duplication of entries in the device list

## Breakdown

- Moving initial `enumerateDevices()` up in order before starting connection listeners

## Validation

- [Bulleted summary of validation steps]
- [eg. Add new unit tests to validate changes]
- [eg. Verified all CI checks pass on the feature branch]

## Additional Notes

Related reported issues:
https://github.com/twilio/audioswitch/issues/114
https://github.com/twilio/audioswitch/issues/120

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
