### PR TITLE
Race conditions in changing states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-### 1.1.8 (Mar 6, 2023)
+### 1.1.8 (Mar 17, 2023)
 
 Bug Fixes
 
 - Fixed issue where some Samsung Galaxy devices (S9, S21) would not route audio through USB headset when MODE_IN_COMMUNICATION is set.
+- Fixed issue where IllegalStateException would be thrown when activating selected AudioDevice shortly after starting AudioSwitch.
+- Fixed issue where after stopping AudioSwitch while having an active Bluetooth device would result in permanent audio focus gain.
 
 ### 1.1.7 (Feb 21, 2023)
 

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -157,10 +157,10 @@ class AudioSwitch {
         audioDeviceChangeListener = listener
         when (state) {
             STOPPED -> {
+                state = STARTED
                 enumerateDevices()
                 bluetoothHeadsetManager?.start(bluetoothDeviceConnectionListener)
                 wiredHeadsetReceiver.start(wiredDeviceConnectionListener)
-                state = STARTED
             }
             else -> {
                 logger.d(TAG, "Redundant start() invocation while already in the started or activated state")
@@ -197,13 +197,13 @@ class AudioSwitch {
     fun activate() {
         when (state) {
             STARTED -> {
+                state = ACTIVATED
                 audioDeviceManager.cacheAudioState()
 
                 // Always set mute to false for WebRTC
                 audioDeviceManager.mute(false)
                 audioDeviceManager.setAudioFocus()
                 selectedDevice?.let { activate(it) }
-                state = ACTIVATED
             }
             ACTIVATED -> selectedDevice?.let { activate(it) }
             STOPPED -> throw IllegalStateException()
@@ -217,11 +217,11 @@ class AudioSwitch {
     fun deactivate() {
         when (state) {
             ACTIVATED -> {
+                state = STARTED
                 bluetoothHeadsetManager?.deactivate()
 
                 // Restore stored audio state
                 audioDeviceManager.restoreAudioState()
-                state = STARTED
             }
             STARTED, STOPPED -> {
             }
@@ -358,10 +358,10 @@ class AudioSwitch {
             } ?: false
 
     private fun closeListeners() {
+        state = STOPPED
         bluetoothHeadsetManager?.stop()
         wiredHeadsetReceiver.stop()
         audioDeviceChangeListener = null
-        state = STOPPED
     }
 
     companion object {


### PR DESCRIPTION
## Description

Move AudioSwitch state change at the beginning of every flow execution, to eliminate two potential race conditions:
 - Incorrect state and exception thrown when selected device is activated shortly after starting the AudioSwitch
 - Bluetooth device is reactivated after stopping AudioSwitch due to incorrect state which caused permanent audio focus (only fixed by reconnecting the Bluetooth device). This also made device to not appear on the list since it was always in active audio connected state.

## Breakdown

- Move state change before any other execution

## Validation

- [Bulleted summary of validation steps]
- [eg. Add new unit tests to validate changes]
- [eg. Verified all CI checks pass on the feature branch]

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
