### PR TITLE
Fix the detection of earpiece for non-cellular devices.

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioDeviceManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioDeviceManager.kt
@@ -27,11 +27,22 @@ internal class AudioDeviceManager(
     private var savedSpeakerphoneEnabled = false
     private var audioRequest: AudioFocusRequest? = null
 
+    @SuppressLint("NewApi")
     fun hasEarpiece(): Boolean {
-        val hasEarpiece = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
-        if (hasEarpiece) {
-            logger.d(TAG, "Earpiece available")
-        }
+        var hasEarpiece = false
+        if (build.getVersion() >= Build.VERSION_CODES.M &&
+            context.packageManager
+                .hasSystemFeature(PackageManager.FEATURE_AUDIO_OUTPUT)) {
+            val devices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            for (device in devices) {
+                if (device.type == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE) {
+                    logger.d(TAG, "Builtin Earpiece available")
+                    hasEarpiece= true
+                }
+            }
+        } else {
+			hasEarpiece = context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
+		}
         return hasEarpiece
     }
 


### PR DESCRIPTION
## Description

Fix the detection of earpiece for non-cellular devices.

## Breakdown

- update in function "hasEarpiece"
- use "AudioDeviceInfo.TYPE_BUILTIN_EARPIECE" to detect earpiece

## Validation

- test the library in Zebra TC52 device

## Additional Notes

Zebra TC52, TC51, TC53 devices do not have telephony but they have built-in earpiece for VoIP use cases.
Zebra ET45 tablet device has telephony but does not have built-in earpiece.

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
