### PR TITLE
VBLOCKS-2801 bluetooth listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.1.10 (March 21, 2024)
+
+Enhancements
+
+- BluetoothHeadsetConnectionListener now can be added to AudioSwitch to notify when bluetooth device has connected or failed to connect.
+
 ### 1.1.9 (July 13, 2023)
 
 Enhancements

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Multiple connected bluetooth headsets are supported.
   - The library will accurately display the up to date active bluetooth headset within the `AudioSwitch` `availableAudioDevices` and `selectedAudioDevice` functions.
     - Other connected headsets are not stored by the library at this moment.
   - In the event of a failure to connecting audio to a bluetooth headset, the library will revert the selected audio device (this is usually the Earpiece on a phone).
+    - Additionally [BluetoothHeadsetConnectionListener](audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetConnectionListener.kt) can be provided to AudioSwitch constructor to monitor state changes and connection failures.
   - If a user would like to switch between multiple Bluetooth headsets, then they need to switch the active bluetooth headset from the system Bluetooth settings.
     - The newly activated headset will be propagated to the `AudioSwitch` `availableAudioDevices` and `selectedAudioDevice` functions.
 

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioSwitchIntegrationTest.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/AudioSwitchIntegrationTest.kt
@@ -87,7 +87,7 @@ class AudioSwitchIntegrationTest : AndroidTestBase() {
             }
         }
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            val audioSwitch = AudioSwitch(getTargetContext(), true, audioFocusChangeListener)
+            val audioSwitch = AudioSwitch(getTargetContext(), null, true, audioFocusChangeListener)
             audioSwitch.start { _, _ -> }
             audioSwitch.activate()
         }
@@ -117,7 +117,7 @@ class AudioSwitchIntegrationTest : AndroidTestBase() {
         val audioFocusUtil = AudioFocusUtil(audioManager, audioFocusChangeListener)
         audioFocusUtil.requestFocus()
 
-        val audioSwitch = AudioSwitch(getTargetContext(), true)
+        val audioSwitch = AudioSwitch(getTargetContext(), null, true)
         InstrumentationRegistry.getInstrumentation().runOnMainSync {
             audioSwitch.start { _, _ -> }
             audioSwitch.activate()

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/AutomaticDeviceSelectionTest.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/AutomaticDeviceSelectionTest.kt
@@ -45,7 +45,7 @@ class AutomaticDeviceSelectionTest : AndroidTestBase() {
 
             override fun onBluetoothHeadsetActivationError() {}
         }
-        val (audioSwitch, bluetoothHeadsetReceiver, wiredHeadsetReceiver) = setupFakeAudioSwitch(context, bluetoothListener =  bluetoothListener)
+        val (audioSwitch, bluetoothHeadsetReceiver, wiredHeadsetReceiver) = setupFakeAudioSwitch(context, bluetoothListener = bluetoothListener)
 
         audioSwitch.start { _, _ -> }
         simulateBluetoothSystemIntent(context, bluetoothHeadsetReceiver)

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/AutomaticDeviceSelectionTest.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/AutomaticDeviceSelectionTest.kt
@@ -43,6 +43,8 @@ class AutomaticDeviceSelectionTest : AndroidTestBase() {
                 bluetoothConnectedLatch.countDown()
             }
 
+            override fun onBluetoothScoStateChanged(state: Int) {}
+
             override fun onBluetoothHeadsetActivationError() {}
         }
         val (audioSwitch, bluetoothHeadsetReceiver, wiredHeadsetReceiver) = setupFakeAudioSwitch(context, bluetoothListener = bluetoothListener)

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -30,7 +30,7 @@ internal fun setupFakeAudioSwitch(
             Earpiece::class.java,
             Speakerphone::class.java,
         ),
-    bluetoothListener: BluetoothHeadsetConnectionListener? = null
+    bluetoothListener: BluetoothHeadsetConnectionListener? = null,
 ): Triple<AudioSwitch, BluetoothHeadsetManager, WiredHeadsetReceiver> {
     val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     val logger = ProductionLogger(true)

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -14,6 +14,7 @@ import com.twilio.audioswitch.android.DEVICE_NAME
 import com.twilio.audioswitch.android.FakeBluetoothIntentProcessor
 import com.twilio.audioswitch.android.HEADSET_NAME
 import com.twilio.audioswitch.android.ProductionLogger
+import com.twilio.audioswitch.bluetooth.BluetoothHeadsetConnectionListener
 import com.twilio.audioswitch.bluetooth.BluetoothHeadsetManager
 import com.twilio.audioswitch.wired.INTENT_STATE
 import com.twilio.audioswitch.wired.STATE_PLUGGED
@@ -29,6 +30,7 @@ internal fun setupFakeAudioSwitch(
             Earpiece::class.java,
             Speakerphone::class.java,
         ),
+    bluetoothListener: BluetoothHeadsetConnectionListener? = null
 ): Triple<AudioSwitch, BluetoothHeadsetManager, WiredHeadsetReceiver> {
     val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     val logger = ProductionLogger(true)
@@ -56,6 +58,7 @@ internal fun setupFakeAudioSwitch(
     return Triple(
         AudioSwitch(
             context,
+            bluetoothListener,
             logger,
             {},
             preferredDevicesList,

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -111,13 +111,13 @@ class AudioSwitch {
         bluetoothHeadsetConnectionListener: BluetoothHeadsetConnectionListener? = null,
         loggingEnabled: Boolean = false,
         audioFocusChangeListener: OnAudioFocusChangeListener = OnAudioFocusChangeListener {},
-        preferredDeviceList: List<Class<out AudioDevice>> = defaultPreferredDeviceList
+        preferredDeviceList: List<Class<out AudioDevice>> = defaultPreferredDeviceList,
     ) : this(
         context.applicationContext,
         bluetoothHeadsetConnectionListener,
         ProductionLogger(loggingEnabled),
         audioFocusChangeListener,
-        preferredDeviceList
+        preferredDeviceList,
     )
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -139,7 +139,7 @@ class AudioSwitch {
             logger,
             BluetoothAdapter.getDefaultAdapter(),
             audioDeviceManager,
-        )
+        ),
     ) {
         this.logger = logger
         this.bluetoothHeadsetConnectionListener = bluetoothHeadsetConnectionListener

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -59,6 +59,10 @@ class AudioSwitch {
             bluetoothHeadsetConnectionListener?.onBluetoothHeadsetStateChanged(headsetName, state)
         }
 
+        override fun onBluetoothScoStateChanged(state: Int) {
+            bluetoothHeadsetConnectionListener?.onBluetoothScoStateChanged(state)
+        }
+
         override fun onBluetoothHeadsetActivationError() {
             if (userSelectedDevice is BluetoothHeadset) userSelectedDevice = null
             enumerateDevices()

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetConnectionListener.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetConnectionListener.kt
@@ -1,6 +1,7 @@
 package com.twilio.audioswitch.bluetooth
 
 import android.bluetooth.BluetoothHeadset
+import android.media.AudioManager
 
 /**
  * Notifies if Bluetooth device state has changed (connect, disconnect, audio connect, audio disconnect) or failed to connect.
@@ -13,5 +14,13 @@ interface BluetoothHeadsetConnectionListener {
      */
     fun onBluetoothHeadsetStateChanged(headsetName: String? = null, state: Int = 0)
 
+    /**
+     * @param state provided by [AudioManager]
+     */
+    fun onBluetoothScoStateChanged(state: Int = 0)
+
+    /**
+     * Triggered when Bluetooth SCO job has timed out.
+     */
     fun onBluetoothHeadsetActivationError()
 }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetConnectionListener.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetConnectionListener.kt
@@ -1,6 +1,17 @@
 package com.twilio.audioswitch.bluetooth
 
-internal interface BluetoothHeadsetConnectionListener {
-    fun onBluetoothHeadsetStateChanged(headsetName: String? = null)
+import android.bluetooth.BluetoothHeadset
+
+/**
+ * Notifies if Bluetooth device state has changed (connect, disconnect, audio connect, audio disconnect) or failed to connect.
+ */
+interface BluetoothHeadsetConnectionListener {
+
+    /**
+     * @param headsetName name of the headset
+     * @param state provided by [BluetoothHeadset]
+     */
+    fun onBluetoothHeadsetStateChanged(headsetName: String? = null, state: Int = 0)
+
     fun onBluetoothHeadsetActivationError()
 }

--- a/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManager.kt
@@ -123,7 +123,7 @@ internal constructor(
                                 "Bluetooth headset $bluetoothDevice connected",
                             )
                             connect()
-                            headsetListener?.onBluetoothHeadsetStateChanged(bluetoothDevice.name)
+                            headsetListener?.onBluetoothHeadsetStateChanged(bluetoothDevice.name, STATE_CONNECTED)
                         }
                         STATE_DISCONNECTED -> {
                             logger.d(
@@ -131,13 +131,13 @@ internal constructor(
                                 "Bluetooth headset $bluetoothDevice disconnected",
                             )
                             disconnect()
-                            headsetListener?.onBluetoothHeadsetStateChanged()
+                            headsetListener?.onBluetoothHeadsetStateChanged(state = STATE_DISCONNECTED)
                         }
                         STATE_AUDIO_CONNECTED -> {
                             logger.d(TAG, "Bluetooth audio connected on device $bluetoothDevice")
                             enableBluetoothScoJob.cancelBluetoothScoJob()
                             headsetState = AudioActivated
-                            headsetListener?.onBluetoothHeadsetStateChanged()
+                            headsetListener?.onBluetoothHeadsetStateChanged(state = STATE_AUDIO_CONNECTED)
                         }
                         STATE_AUDIO_DISCONNECTED -> {
                             logger.d(TAG, "Bluetooth audio disconnected on device $bluetoothDevice")
@@ -150,7 +150,7 @@ internal constructor(
                                 enableBluetoothScoJob.executeBluetoothScoJob()
                             }
 
-                            headsetListener?.onBluetoothHeadsetStateChanged()
+                            headsetListener?.onBluetoothHeadsetStateChanged(state = STATE_AUDIO_DISCONNECTED)
                         }
                         else -> {}
                     }

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -34,6 +34,7 @@ public class AudioSwitchJavaTest extends BaseTest {
         javaAudioSwitch =
                 new AudioSwitch(
                         getContext$audioswitch_debug(),
+                        null,
                         new UnitTestLogger(false),
                         getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         getPreferredDeviceList$audioswitch_debug(),
@@ -130,6 +131,7 @@ public class AudioSwitchJavaTest extends BaseTest {
         javaAudioSwitch =
                 new AudioSwitch(
                         getContext$audioswitch_debug(),
+                        getBluetoothListener$audioswitch_debug(),
                         getLogger$audioswitch_debug(),
                         getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         preferredDeviceList,

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -94,6 +94,7 @@ class AudioSwitchTest : BaseTest() {
     fun `start should not start the HeadsetManager if it is null`() {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -201,6 +202,7 @@ class AudioSwitchTest : BaseTest() {
     fun `stop should not stop the BluetoothHeadsetManager if it is null and if transitioning from the started state`() {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -219,6 +221,7 @@ class AudioSwitchTest : BaseTest() {
     fun `stop should not stop the BluetoothHeadsetManager if it is null and if transitioning from the activated state`() {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -441,6 +444,7 @@ class AudioSwitchTest : BaseTest() {
     fun `constructor should throw an IllegalArgumentException given duplicate preferred devices`() {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -460,6 +464,7 @@ class AudioSwitchTest : BaseTest() {
         // Switch selection order so BT isn't automatically selected
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -501,6 +506,7 @@ class AudioSwitchTest : BaseTest() {
     ) {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -525,6 +531,7 @@ class AudioSwitchTest : BaseTest() {
     ) {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -550,6 +557,7 @@ class AudioSwitchTest : BaseTest() {
     ) {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -574,6 +582,7 @@ class AudioSwitchTest : BaseTest() {
     ) {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
@@ -609,6 +618,7 @@ class AudioSwitchTest : BaseTest() {
     ) {
         audioSwitch = AudioSwitch(
             context = context,
+            bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -12,6 +12,7 @@ import com.twilio.audioswitch.AudioDevice.Earpiece
 import com.twilio.audioswitch.AudioDevice.Speakerphone
 import com.twilio.audioswitch.AudioDevice.WiredHeadset
 import com.twilio.audioswitch.android.BuildWrapper
+import com.twilio.audioswitch.bluetooth.BluetoothHeadsetConnectionListener
 import com.twilio.audioswitch.bluetooth.BluetoothHeadsetManager
 import com.twilio.audioswitch.wired.WiredHeadsetReceiver
 import org.hamcrest.CoreMatchers
@@ -29,6 +30,7 @@ open class BaseTest {
         whenever(mock.bluetoothClass).thenReturn(bluetoothClass)
     }
     internal val context = mock<Context>()
+    internal val bluetoothListener = mock<BluetoothHeadsetConnectionListener>()
     internal val logger = UnitTestLogger()
     internal val audioManager = setupAudioManagerMock()
     internal val bluetoothAdapter = mock<BluetoothAdapter>()
@@ -68,6 +70,7 @@ open class BaseTest {
 
     internal var audioSwitch = AudioSwitch(
         context = context,
+        bluetoothHeadsetConnectionListener = bluetoothListener,
         logger = logger,
         audioDeviceManager = audioDeviceManager,
         wiredHeadsetReceiver = wiredHeadsetReceiver,

--- a/audioswitch/src/test/java/com/twilio/audioswitch/TestUtil.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/TestUtil.kt
@@ -43,7 +43,7 @@ internal fun BaseTest.assertBluetoothHeadsetSetup() {
         headsetManager,
         BluetoothProfile.HEADSET,
     )
-    verify(context, times(2)).registerReceiver(eq(headsetManager), isA())
+    verify(context, times(3)).registerReceiver(eq(headsetManager), isA())
 }
 
 internal fun setupPermissionsCheckStrategy() =

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
@@ -205,7 +205,7 @@ class BluetoothHeadsetManagerTest : BaseTest() {
         headsetManager.onReceive(context, intent)
 
         val invocationCount = if (isNewDeviceConnected) 1 else 0
-        verify(headsetListener, times(invocationCount)).onBluetoothHeadsetStateChanged(DEVICE_NAME)
+        verify(headsetListener, times(invocationCount)).onBluetoothHeadsetStateChanged(DEVICE_NAME, BluetoothHeadset.STATE_CONNECTED)
     }
 
     @Parameters(method = "parameters")

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
@@ -225,15 +225,15 @@ class BluetoothHeadsetManagerTest : BaseTest() {
         headsetManager.onReceive(context, intent)
 
         val invocationCount = if (isDeviceDisconnected) 1 else 0
-        verify(headsetListener, times(invocationCount)).onBluetoothHeadsetStateChanged()
+        verify(headsetListener, times(invocationCount)).onBluetoothHeadsetStateChanged(headsetName = "Bluetooth")
     }
 
     @Test
-    fun `onReceive should not register a new device when an ACL connected event is received with a null bluetooth device`() {
+    fun `onReceive should trigger once for sco disconnect when an ACL connected event is received with a null bluetooth device`() {
         whenever(expectedBluetoothDevice.bluetoothClass).thenReturn(null)
         simulateNewBluetoothHeadsetConnection()
 
-        verifyNoInteractions(headsetListener)
+        verify(headsetListener, times(1)).onBluetoothScoStateChanged(0)
     }
 
     @Test


### PR DESCRIPTION
## Description

Bluetooth listener can now be added to AudioSwitch to monitor bluetooth device connections.

## Breakdown

- Make BluetoothHeadsetConnectionListener public
- BluetoothHeadsetConnectionListener onBluetoothHeadsetStateChanged now also returns state
- Update README and CHANGELOG
- Update tests and add test case for BluetoothHeadsetConnectionListener

## Validation

- [Bulleted summary of validation steps]
- [eg. Add new unit tests to validate changes]
- [eg. Verified all CI checks pass on the feature branch]

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
