### PR TITLE
VBLOCKS-2802 Bluetooth permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 # Changelog
-### 1.1.10 (In Progress)
+### 1.1.10 (May 2, 2024)
 
 Enhancements
 
 - Updated gradle version to 8.4
 - Updated gradle plugin to 8.3.1
-
-
-### 1.1.10 (March 21, 2024)
-
-Enhancements
-
 - BluetoothHeadsetConnectionListener now can be added to AudioSwitch to notify when bluetooth device has connected or failed to connect.
+- BLUETOOTH_CONNECT and/or BLUETOOTH permission have been removed and are optional now. If not provided bluetooth device
+will not appear in the list of available devices and no callbacks will be received for BluetoothHeadsetConnectionListener.
 
 ### 1.1.9 (July 13, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-### 1.1.10 (May 2, 2024)
+### 1.1.10 (In progress)
 
 Enhancements
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ audioSwitch.deactivate()
 ## Bluetooth Support
 
 Multiple connected bluetooth headsets are supported.
+  - Bluetooth support requires BLUETOOTH_CONNECT or BLUETOOTH permission.
   - The library will accurately display the up to date active bluetooth headset within the `AudioSwitch` `availableAudioDevices` and `selectedAudioDevice` functions.
     - Other connected headsets are not stored by the library at this moment.
   - In the event of a failure to connecting audio to a bluetooth headset, the library will revert the selected audio device (this is usually the Earpiece on a phone).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ audioSwitch.deactivate()
 ## Bluetooth Support
 
 Multiple connected bluetooth headsets are supported.
-  - Bluetooth support requires BLUETOOTH_CONNECT or BLUETOOTH permission.
+  - Bluetooth support requires BLUETOOTH_CONNECT or BLUETOOTH permission. These permission have to be added to the application using AudioSwitch, they do not come with the library.
   - The library will accurately display the up to date active bluetooth headset within the `AudioSwitch` `availableAudioDevices` and `selectedAudioDevice` functions.
     - Other connected headsets are not stored by the library at this moment.
   - In the event of a failure to connecting audio to a bluetooth headset, the library will revert the selected audio device (this is usually the Earpiece on a phone).

--- a/audioswitch/src/androidTest/AndroidManifest.xml
+++ b/audioswitch/src/androidTest/AndroidManifest.xml
@@ -6,4 +6,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH"  android:maxSdkVersion="30"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
 </manifest>

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -64,7 +64,6 @@ internal fun setupFakeAudioSwitch(
             preferredDevicesList,
             audioDeviceManager,
             wiredHeadsetReceiver,
-            headsetManager,
         ),
         headsetManager!!,
         wiredHeadsetReceiver,

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -64,6 +64,7 @@ internal fun setupFakeAudioSwitch(
             preferredDevicesList,
             audioDeviceManager,
             wiredHeadsetReceiver,
+            bluetoothHeadsetManager = headsetManager,
         ),
         headsetManager!!,
         wiredHeadsetReceiver,

--- a/audioswitch/src/main/AndroidManifest.xml
+++ b/audioswitch/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-permission android:name="android.permission.BLUETOOTH"  android:maxSdkVersion="30"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
 </manifest>

--- a/audioswitch/src/main/java/com/twilio/audioswitch/android/BluetoothDeviceWrapperImpl.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/android/BluetoothDeviceWrapperImpl.kt
@@ -1,9 +1,11 @@
 package com.twilio.audioswitch.android
 
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
 
 internal const val DEFAULT_DEVICE_NAME = "Bluetooth"
 
+@SuppressLint("MissingPermission")
 internal data class BluetoothDeviceWrapperImpl(
     val device: BluetoothDevice,
     override val name: String = device.name ?: DEFAULT_DEVICE_NAME,

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -39,8 +39,7 @@ public class AudioSwitchJavaTest extends BaseTest {
                         getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         getPreferredDeviceList$audioswitch_debug(),
                         getAudioDeviceManager$audioswitch_debug(),
-                        getWiredHeadsetReceiver$audioswitch_debug(),
-                        getHeadsetManager$audioswitch_debug());
+                        getWiredHeadsetReceiver$audioswitch_debug());
     }
 
     @Test
@@ -136,8 +135,7 @@ public class AudioSwitchJavaTest extends BaseTest {
                         getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         preferredDeviceList,
                         getAudioDeviceManager$audioswitch_debug(),
-                        getWiredHeadsetReceiver$audioswitch_debug(),
-                        getHeadsetManager$audioswitch_debug());
+                        getWiredHeadsetReceiver$audioswitch_debug());
 
         startAudioSwitch();
 

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -39,7 +39,9 @@ public class AudioSwitchJavaTest extends BaseTest {
                         getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         getPreferredDeviceList$audioswitch_debug(),
                         getAudioDeviceManager$audioswitch_debug(),
-                        getWiredHeadsetReceiver$audioswitch_debug());
+                        getWiredHeadsetReceiver$audioswitch_debug(),
+                        getPermissionsStrategyProxy$audioswitch_debug(),
+                        getHeadsetManager$audioswitch_debug());
     }
 
     @Test
@@ -135,7 +137,9 @@ public class AudioSwitchJavaTest extends BaseTest {
                         getDefaultAudioFocusChangeListener$audioswitch_debug(),
                         preferredDeviceList,
                         getAudioDeviceManager$audioswitch_debug(),
-                        getWiredHeadsetReceiver$audioswitch_debug());
+                        getWiredHeadsetReceiver$audioswitch_debug(),
+                        getPermissionsStrategyProxy$audioswitch_debug(),
+                        getHeadsetManager$audioswitch_debug());
 
         startAudioSwitch();
 

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -98,7 +98,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -206,7 +205,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -224,8 +222,6 @@ class AudioSwitchTest : BaseTest() {
             bluetoothHeadsetConnectionListener = bluetoothListener,
             logger = logger,
             audioDeviceManager = audioDeviceManager,
-            wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -448,7 +444,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = null,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = listOf(
                 Speakerphone::class.java,
@@ -468,7 +463,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = headsetManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = listOf(
                 Earpiece::class.java,
@@ -510,7 +504,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = headsetManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -535,7 +528,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = headsetManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -561,7 +553,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = headsetManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -586,7 +577,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = headsetManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )
@@ -622,7 +612,6 @@ class AudioSwitchTest : BaseTest() {
             logger = logger,
             audioDeviceManager = audioDeviceManager,
             wiredHeadsetReceiver = wiredHeadsetReceiver,
-            headsetManager = headsetManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
         )

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -100,6 +100,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = null,
         )
 
         audioSwitch.start(audioDeviceChangeListener)
@@ -207,6 +209,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = null,
         )
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.stop()
@@ -224,6 +228,8 @@ class AudioSwitchTest : BaseTest() {
             audioDeviceManager = audioDeviceManager,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = null,
         )
         audioSwitch.start(audioDeviceChangeListener)
         audioSwitch.activate()
@@ -451,6 +457,8 @@ class AudioSwitchTest : BaseTest() {
                 Earpiece::class.java,
                 Speakerphone::class.java,
             ),
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
     }
 
@@ -470,7 +478,8 @@ class AudioSwitchTest : BaseTest() {
                 Speakerphone::class.java,
                 AudioDevice.BluetoothHeadset::class.java,
             ),
-
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
         val secondBluetoothDevice = mock<BluetoothDevice> {
             whenever(mock.name).thenReturn("$DEVICE_NAME 2")
@@ -506,6 +515,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
 
         audioSwitch.run {
@@ -530,6 +541,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
 
         audioSwitch.run {
@@ -555,6 +568,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
 
         audioSwitch.run {
@@ -579,6 +594,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
 
         audioSwitch.run {
@@ -614,6 +631,8 @@ class AudioSwitchTest : BaseTest() {
             wiredHeadsetReceiver = wiredHeadsetReceiver,
             audioFocusChangeListener = defaultAudioFocusChangeListener,
             preferredDeviceList = preferredDeviceList,
+            permissionsCheckStrategy = permissionsStrategyProxy,
+            bluetoothHeadsetManager = headsetManager,
         )
 
         audioSwitch.run {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -75,6 +75,8 @@ open class BaseTest {
         wiredHeadsetReceiver = wiredHeadsetReceiver,
         audioFocusChangeListener = defaultAudioFocusChangeListener,
         preferredDeviceList = preferredDeviceList,
+        permissionsCheckStrategy = permissionsStrategyProxy,
+        bluetoothHeadsetManager = headsetManager,
     )
 
     internal fun assertBluetoothHeadsetTeardown() {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -65,7 +65,6 @@ open class BaseTest {
         bluetoothScoHandler = handler,
         systemClockWrapper = systemClockWrapper,
         headsetProxy = headsetProxy,
-        permissionsRequestStrategy = permissionsStrategyProxy,
     )
 
     internal var audioSwitch = AudioSwitch(
@@ -74,7 +73,6 @@ open class BaseTest {
         logger = logger,
         audioDeviceManager = audioDeviceManager,
         wiredHeadsetReceiver = wiredHeadsetReceiver,
-        headsetManager = headsetManager,
         audioFocusChangeListener = defaultAudioFocusChangeListener,
         preferredDeviceList = preferredDeviceList,
     )

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
@@ -355,7 +355,6 @@ class BluetoothHeadsetManagerTest : BaseTest() {
             bluetoothScoHandler = handler,
             systemClockWrapper = systemClockWrapper,
             headsetProxy = headsetProxy,
-            permissionsRequestStrategy = permissionsStrategyProxy,
         )
 
         headsetManager.headsetState = Connected
@@ -476,7 +475,6 @@ class BluetoothHeadsetManagerTest : BaseTest() {
             handler,
             systemClockWrapper,
             headsetProxy = headsetProxy,
-            permissionsRequestStrategy = permissionsStrategyProxy,
         )
     }
 }


### PR DESCRIPTION
## Description

BLUTOOTH_CONNECT or BLUETOOTH permission is now optional. When bluetooth permissions are not granted by the app using AudioSwitch the bluetooth devices will not appear or be selectable.

## Breakdown

- Remove BLUTOOTH_CONNECT and BLUETOOTH permissions from Manifest
- Move bluetooth permission check to AudioSwitch class
- Remove permission checks from BluetoothHeadsetManager
- Update unit and integration tests

## Validation

- Tests pass
- Run manual validation with voice quickstart

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
