### PR TITLE
QSDK-10497 broadcast receivers

### DIFF
--- a/audioswitch/src/main/java/com/twilio/audioswitch/android/BroadcastReceiverCompat.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/android/BroadcastReceiverCompat.kt
@@ -1,0 +1,21 @@
+package com.twilio.audioswitch.android
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.IntentFilter
+import android.os.Build
+
+internal fun registerReceiverCompat(
+    context: Context,
+    broadcastReceiver: BroadcastReceiver,
+    intentFilter: IntentFilter,
+    exported: Boolean,
+    broadcastPermission: String?,
+) {
+    if (Build.VERSION.SDK_INT >= 34 && context.applicationInfo.targetSdkVersion >= 34) {
+        val flag = if (exported) Context.RECEIVER_EXPORTED else Context.RECEIVER_NOT_EXPORTED
+        context.registerReceiver(broadcastReceiver, intentFilter, broadcastPermission, null, flag)
+    } else {
+        context.registerReceiver(broadcastReceiver, intentFilter, broadcastPermission, null)
+    }
+}

--- a/audioswitch/src/main/java/com/twilio/audioswitch/wired/WiredHeadsetReceiver.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/wired/WiredHeadsetReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import com.twilio.audioswitch.android.Logger
+import com.twilio.audioswitch.android.registerReceiverCompat
 
 private const val TAG = "WiredHeadsetReceiver"
 internal const val STATE_UNPLUGGED = 0
@@ -37,7 +38,13 @@ internal class WiredHeadsetReceiver(
 
     fun start(deviceListener: WiredDeviceConnectionListener) {
         this.deviceListener = deviceListener
-        context.registerReceiver(this, IntentFilter(Intent.ACTION_HEADSET_PLUG))
+        registerReceiverCompat(
+            context,
+            this,
+            IntentFilter(Intent.ACTION_HEADSET_PLUG),
+            true,
+            null,
+        )
     }
 
     fun stop() {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import com.twilio.audioswitch.AudioDevice.BluetoothHeadset;
 import com.twilio.audioswitch.AudioDevice.Earpiece;
@@ -26,11 +27,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AudioSwitchJavaTest extends BaseTest {
     private AudioSwitch javaAudioSwitch;
     @Mock PackageManager packageManager;
+    @Mock ApplicationInfo applicationInfo;
 
     @Before
     public void setUp() {
         when(packageManager.hasSystemFeature(any())).thenReturn(true);
         when(getContext$audioswitch_debug().getPackageManager()).thenReturn(packageManager);
+        when(getContext$audioswitch_debug().getApplicationInfo()).thenReturn(applicationInfo);
         javaAudioSwitch =
                 new AudioSwitch(
                         getContext$audioswitch_debug(),

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -49,6 +50,7 @@ class AudioSwitchTest : BaseTest() {
     @Before
     fun setUp() {
         whenever(context.packageManager).thenReturn(packageManager)
+        whenever(context.applicationInfo).thenReturn(applicationInfo)
     }
 
     @Test
@@ -58,7 +60,7 @@ class AudioSwitchTest : BaseTest() {
         assertBluetoothHeadsetSetup()
 
         assertThat(wiredHeadsetReceiver.deviceListener, equalTo(audioSwitch.wiredDeviceConnectionListener))
-        verify(context).registerReceiver(eq(wiredHeadsetReceiver), isA())
+        verify(context).registerReceiver(eq(wiredHeadsetReceiver), isA(), isNull(), isNull())
     }
 
     @Test

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothHeadset
 import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.media.AudioManager.OnAudioFocusChangeListener
 import com.twilio.audioswitch.AudioDevice.Earpiece
 import com.twilio.audioswitch.AudioDevice.Speakerphone
@@ -30,6 +31,7 @@ open class BaseTest {
         whenever(mock.bluetoothClass).thenReturn(bluetoothClass)
     }
     internal val context = mock<Context>()
+    internal val applicationInfo = mock<ApplicationInfo>()
     internal val bluetoothListener = mock<BluetoothHeadsetConnectionListener>()
     internal val logger = UnitTestLogger()
     internal val audioManager = setupAudioManagerMock()

--- a/audioswitch/src/test/java/com/twilio/audioswitch/TestUtil.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/TestUtil.kt
@@ -9,6 +9,7 @@ import com.twilio.audioswitch.bluetooth.BluetoothScoJob
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -43,7 +44,7 @@ internal fun BaseTest.assertBluetoothHeadsetSetup() {
         headsetManager,
         BluetoothProfile.HEADSET,
     )
-    verify(context, times(3)).registerReceiver(eq(headsetManager), isA())
+    verify(context, times(3)).registerReceiver(eq(headsetManager), isA(), isA(), isNull())
 }
 
 internal fun setupPermissionsCheckStrategy() =

--- a/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/bluetooth/BluetoothHeadsetManagerTest.kt
@@ -39,6 +39,7 @@ class BluetoothHeadsetManagerTest : BaseTest() {
     @Before
     fun setUp() {
         initializeManagerWithMocks()
+        whenever(context.applicationInfo).thenReturn(applicationInfo)
     }
 
     @Test

--- a/audioswitch/src/test/java/com/twilio/audioswitch/wired/WiredHeadsetReceiverTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/wired/WiredHeadsetReceiverTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -92,7 +93,7 @@ class WiredHeadsetReceiverTest {
     fun `start should register the broadcast receiver`() {
         wiredHeadsetReceiver.start(wiredDeviceConnectionListener)
 
-        verify(context).registerReceiver(eq(wiredHeadsetReceiver), isA())
+        verify(context).registerReceiver(eq(wiredHeadsetReceiver), isA(), isNull(), isNull())
     }
 
     @Test


### PR DESCRIPTION
## Description

Add registerReceiverCompat function that includes broadcast permission and exported flag

## Breakdown

- Update BroadcastReceivers to include permission flag needed for bluetooth broadcasts
- Check if target and device version is >= 34 for adding exported flag
- Update unit tests

## Validation

- Manual validation required

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
