### PR TITLE
VBLOCKS-3834 Make AudioDeviceChangeListener optional parameter when calling start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+### 1.2.1 (In progress)
+
+Enhancements
+
+- AudioDeviceChangeListener is now optional parameter when calling `AudioSwitch.start(listener: AudioDeviceChangeListener? = null)`
+- Added `AudioSwitch.addAudioDeviceChangeListener(listener: AudioDeviceChangeListener)` and `AudioSwitch.removeAudioDeviceChangeListener()`
+
 ### 1.2.0 (June 3, 2024)
 
 Enhancements

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -184,12 +184,14 @@ class AudioSwitch {
     }
 
     /**
-     * Starts listening for audio device changes and calls the [listener] upon each change.
+     * Starts listening for audio device changes and calls the [listener] upon each change if listener provided.
      * **Note:** When audio device listening is no longer needed, [AudioSwitch.stop] should be
      * called in order to prevent a memory leak.
      */
-    fun start(listener: AudioDeviceChangeListener) {
-        audioDeviceChangeListener = listener
+    fun start(listener: AudioDeviceChangeListener? = null) {
+        listener?.let {
+            audioDeviceChangeListener = it
+        }
         when (state) {
             STOPPED -> {
                 state = STARTED
@@ -200,6 +202,28 @@ class AudioSwitch {
             else -> {
                 logger.d(TAG, "Redundant start() invocation while already in the started or activated state")
             }
+        }
+    }
+
+    /**
+     * Adds [AudioDeviceChangeListener] and starts listening for audio devices changes and calls
+     */
+    fun addAudioDeviceChangeListener(listener: AudioDeviceChangeListener) {
+        if (audioDeviceChangeListener == null) {
+            audioDeviceChangeListener = listener
+        } else {
+            logger.d(TAG, "Redundant addAudioDeviceChangeListener call, listener already added")
+        }
+    }
+
+    /**
+     * Removes [AudioDeviceChangeListener] and stops listening for audio device changes and calls
+     */
+    fun removeAudioDeviceChangeListener() {
+        if (audioDeviceChangeListener != null) {
+            audioDeviceChangeListener = null
+        } else {
+            logger.d(TAG, "Redundant removeAudioDeviceChangeListener call, AudioDeviceChangeListener is null")
         }
     }
 

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -146,6 +146,31 @@ public class AudioSwitchJavaTest extends BaseTest {
         assertEquals(new Speakerphone(), javaAudioSwitch.getSelectedAudioDevice());
     }
 
+
+    @Test
+    public void shouldAllowAddingAudioDeviceListener() {
+        javaAudioSwitch.start(null);
+        Function2<List<? extends AudioDevice>, AudioDevice, Unit> audioDeviceListener =
+                (audioDevices, audioDevice) -> {
+                    assertFalse(audioDevices.isEmpty());
+                    assertNotNull(audioDevice);
+                    return Unit.INSTANCE;
+                };
+        javaAudioSwitch.addAudioDeviceChangeListener(audioDeviceListener);
+    }
+
+    @Test
+    public void shouldAllowRemovingAudioDeviceListener() {
+        Function2<List<? extends AudioDevice>, AudioDevice, Unit> audioDeviceListener =
+                (audioDevices, audioDevice) -> {
+                    assertFalse(audioDevices.isEmpty());
+                    assertNotNull(audioDevice);
+                    return Unit.INSTANCE;
+                };
+        javaAudioSwitch.start(audioDeviceListener);
+        javaAudioSwitch.removeAudioDeviceChangeListener();
+    }
+
     private void startAudioSwitch() {
         Function2<List<? extends AudioDevice>, AudioDevice, Unit> audioDeviceListener =
                 (audioDevices, audioDevice) -> {

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -146,7 +146,6 @@ public class AudioSwitchJavaTest extends BaseTest {
         assertEquals(new Speakerphone(), javaAudioSwitch.getSelectedAudioDevice());
     }
 
-
     @Test
     public void shouldAllowAddingAudioDeviceListener() {
         javaAudioSwitch.start(null);

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchTest.kt
@@ -69,6 +69,38 @@ class AudioSwitchTest : BaseTest() {
     }
 
     @Test
+    fun `start can be called without audio device change listener`() {
+        audioSwitch.start()
+
+        assertThat(audioSwitch.state, equalTo(STARTED))
+        verifyNoInteractions(audioDeviceChangeListener)
+    }
+
+    @Test
+    fun `should be able to add audio device change listener`() {
+        audioSwitch.start()
+        audioSwitch.addAudioDeviceChangeListener(audioDeviceChangeListener)
+        audioSwitch.selectDevice(Speakerphone())
+        verify(audioDeviceChangeListener).invoke(
+            listOf(Earpiece(), Speakerphone()),
+            Speakerphone(),
+        )
+    }
+
+    @Test
+    fun `should be able to remove audio device change listener`() {
+        audioSwitch.start(audioDeviceChangeListener)
+        audioSwitch.removeAudioDeviceChangeListener()
+        audioSwitch.selectDevice(Speakerphone())
+        audioSwitch.selectDevice(Earpiece())
+        audioSwitch.selectDevice(Speakerphone())
+        verify(audioDeviceChangeListener, times(1)).invoke(
+            listOf(Earpiece(), Speakerphone()),
+            Earpiece(),
+        )
+    }
+
+    @Test
     fun `start should cache the default audio devices and the default selected audio device`() {
         audioSwitch.start(audioDeviceChangeListener)
 


### PR DESCRIPTION
## Description

Make AudioDeviceChangeListener optional parameter when calling start()

## Breakdown

- AudioDeviceChangeListener parameter when calling AudioSwitch.start() can be omitted or be null in java case.
- Adding AudioSwitch.addAudioDeviceChangeListener(listener: AudioDeviceChangeListener) to add listener in case the listener was not passed when calling start()
- Adding AudioSwitch.removeAudioDeviceChangeListener() to remove existing listener.

## Validation

- Unit tests

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
