### PR TITLE
VBLOCKS-3880 BluetoothHeadsetManager should check permission when invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Enhancements
 
 - AudioDeviceChangeListener is now optional parameter when calling `AudioSwitch.start(listener: AudioDeviceChangeListener? = null)`
 - Added `AudioSwitch.setAudioDeviceChangeListener(listener: AudioDeviceChangeListener?)`
+- BluetoothHeadsetManager now checks for permissions every time it is called, creates an instance if null and permissions granted
 
 ### 1.2.0 (June 3, 2024)
 

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -64,7 +64,6 @@ internal fun setupFakeAudioSwitch(
             preferredDevicesList,
             audioDeviceManager,
             wiredHeadsetReceiver,
-            bluetoothHeadsetManager = headsetManager,
         ),
         headsetManager!!,
         wiredHeadsetReceiver,

--- a/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
+++ b/audioswitch/src/androidTest/java/com.twilio.audioswitch/TestUtil.kt
@@ -64,6 +64,7 @@ internal fun setupFakeAudioSwitch(
             preferredDevicesList,
             audioDeviceManager,
             wiredHeadsetReceiver,
+            bluetoothHeadsetManager = headsetManager,
         ),
         headsetManager!!,
         wiredHeadsetReceiver,

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -3,6 +3,7 @@ package com.twilio.audioswitch
 import android.Manifest
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.media.AudioManager
@@ -40,7 +41,7 @@ private const val PERMISSION_ERROR_MESSAGE = "Bluetooth unsupported, permissions
  * @property availableAudioDevices Retrieves the current list of available [AudioDevice]s.
 **/
 class AudioSwitch {
-
+    private val context: Context
     private var logger: Logger = ProductionLogger()
     private val audioDeviceManager: AudioDeviceManager
     private val wiredHeadsetReceiver: WiredHeadsetReceiver
@@ -145,13 +146,15 @@ class AudioSwitch {
         ),
         wiredHeadsetReceiver: WiredHeadsetReceiver = WiredHeadsetReceiver(context, logger),
         permissionsCheckStrategy: PermissionsCheckStrategy = DefaultPermissionsCheckStrategy(context),
+        bluetoothManager: BluetoothManager? = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager,
         bluetoothHeadsetManager: BluetoothHeadsetManager? = BluetoothHeadsetManager.newInstance(
             context,
             logger,
-            BluetoothAdapter.getDefaultAdapter(),
+            bluetoothManager?.adapter,
             audioDeviceManager,
         ),
     ) {
+        this.context = context
         this.logger = logger
         this.bluetoothHeadsetConnectionListener = bluetoothHeadsetConnectionListener
         this.audioDeviceManager = audioDeviceManager
@@ -194,7 +197,7 @@ class AudioSwitch {
             STOPPED -> {
                 state = STARTED
                 enumerateDevices()
-                bluetoothHeadsetManager?.start(bluetoothDeviceConnectionListener)
+                bluetoothHeadsetManager.instance()?.start(bluetoothDeviceConnectionListener)
                 wiredHeadsetReceiver.start(wiredDeviceConnectionListener)
             }
             else -> {
@@ -253,7 +256,7 @@ class AudioSwitch {
         when (state) {
             ACTIVATED -> {
                 state = STARTED
-                bluetoothHeadsetManager?.deactivate()
+                bluetoothHeadsetManager.instance()?.deactivate()
 
                 // Restore stored audio state
                 audioDeviceManager.restoreAudioState()
@@ -284,15 +287,15 @@ class AudioSwitch {
         when (audioDevice) {
             is BluetoothHeadset -> {
                 audioDeviceManager.enableSpeakerphone(false)
-                bluetoothHeadsetManager?.activate()
+                bluetoothHeadsetManager.instance()?.activate()
             }
             is Earpiece, is WiredHeadset -> {
                 audioDeviceManager.enableSpeakerphone(false)
-                bluetoothHeadsetManager?.deactivate()
+                bluetoothHeadsetManager.instance()?.deactivate()
             }
             is Speakerphone -> {
                 audioDeviceManager.enableSpeakerphone(true)
-                bluetoothHeadsetManager?.deactivate()
+                bluetoothHeadsetManager.instance()?.deactivate()
             }
         }
     }
@@ -323,7 +326,7 @@ class AudioSwitch {
              * be the next valid device in the list.
              */
             if (firstAudioDevice is BluetoothHeadset &&
-                bluetoothHeadsetManager?.hasActivationError() == true
+                bluetoothHeadsetManager.instance()?.hasActivationError() == true
             ) {
                 mutableAudioDevices[1]
             } else {
@@ -355,7 +358,7 @@ class AudioSwitch {
                  * headset name received from the ACTION_ACL_CONNECTED intent needs to be passed into this
                  * function.
                  */
-                    bluetoothHeadsetManager?.getHeadset(bluetoothHeadsetName)?.let {
+                    bluetoothHeadsetManager.instance()?.getHeadset(bluetoothHeadsetName)?.let {
                         mutableAudioDevices.add(it)
                     }
                 }
@@ -395,9 +398,22 @@ class AudioSwitch {
 
     private fun closeListeners() {
         state = STOPPED
-        bluetoothHeadsetManager?.stop()
+        bluetoothHeadsetManager.instance()?.stop()
         wiredHeadsetReceiver.stop()
         audioDeviceChangeListener = null
+    }
+
+    private fun BluetoothHeadsetManager?.instance(): BluetoothHeadsetManager? {
+        if (this == null && hasPermissions()) {
+            val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+            return BluetoothHeadsetManager.newInstance(
+                context,
+                logger,
+                bluetoothManager?.adapter,
+                audioDeviceManager,
+            )
+        }
+        return this
     }
 
     internal fun hasPermissions() = permissionsRequestStrategy.hasPermissions()

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -2,7 +2,6 @@ package com.twilio.audioswitch
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager.PERMISSION_GRANTED

--- a/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/AudioSwitchJavaTest.java
@@ -41,6 +41,7 @@ public class AudioSwitchJavaTest extends BaseTest {
                         getAudioDeviceManager$audioswitch_debug(),
                         getWiredHeadsetReceiver$audioswitch_debug(),
                         getPermissionsStrategyProxy$audioswitch_debug(),
+                        getBluetoothManager$audioswitch_debug(),
                         getHeadsetManager$audioswitch_debug());
     }
 
@@ -139,6 +140,7 @@ public class AudioSwitchJavaTest extends BaseTest {
                         getAudioDeviceManager$audioswitch_debug(),
                         getWiredHeadsetReceiver$audioswitch_debug(),
                         getPermissionsStrategyProxy$audioswitch_debug(),
+                        getBluetoothManager$audioswitch_debug(),
                         getHeadsetManager$audioswitch_debug());
 
         startAudioSwitch();

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -4,6 +4,7 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothClass
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothHeadset
+import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.content.Intent
@@ -33,7 +34,9 @@ open class BaseTest {
     internal val bluetoothListener = mock<BluetoothHeadsetConnectionListener>()
     internal val logger = UnitTestLogger()
     internal val audioManager = setupAudioManagerMock()
+    internal val bluetoothManager = mock<BluetoothManager>()
     internal val bluetoothAdapter = mock<BluetoothAdapter>()
+
     internal val audioDeviceChangeListener = mock<AudioDeviceChangeListener>()
     internal val buildWrapper = mock<BuildWrapper>()
     internal val audioFocusRequest = mock<AudioFocusRequestWrapper>()
@@ -76,6 +79,7 @@ open class BaseTest {
         audioFocusChangeListener = defaultAudioFocusChangeListener,
         preferredDeviceList = preferredDeviceList,
         permissionsCheckStrategy = permissionsStrategyProxy,
+        bluetoothManager = bluetoothManager,
         bluetoothHeadsetManager = headsetManager,
     )
 


### PR DESCRIPTION
## Description
BluetoothHeadsetManager should check permission when invoked
[Description of the Pull Request]

## Breakdown

- Check if BluetoothHeadsetManager is not initialised and bluetooth permissions are granted, in that case create a new instance
- Remove deprecated BluetoothAdapter.getDefaultAdapter() in favour of BluetoothManager.adapter

## Validation

- [Bulleted summary of validation steps]
- [eg. Add new unit tests to validate changes]
- [eg. Verified all CI checks pass on the feature branch]

## Additional Notes

[Any additional comments, notes, or information relevant to reviewers.]

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
