### PR TITLE
[VBLOCKS-4911] Fix issue when output list is not updated after permissions approval

### DIFF
--- a/audioswitch/src/androidTest/java/com/twilio/audioswitch/manual/ConnectedBluetoothHeadsetTest.kt
+++ b/audioswitch/src/androidTest/java/com/twilio/audioswitch/manual/ConnectedBluetoothHeadsetTest.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -132,6 +133,7 @@ class ConnectedBluetoothHeadsetTest {
 
     @Test
     fun it_should_remove_bluetooth_device_after_disconnected() {
+        assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
         val bluetoothDeviceConnected = CountDownLatch(1)
         lateinit var actualBluetoothDevice: AudioDevice
         var noBluetoothDeviceAvailable: CountDownLatch? = null
@@ -236,6 +238,7 @@ class ConnectedBluetoothHeadsetTest {
 
     @Test
     fun it_should_automatically_activate_bluetooth_device_if_no_device_selected() {
+        assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
         bluetoothAdapter.disable()
         retryAssertion { assertFalse(bluetoothAdapter.isEnabled) }
         val bluetoothDeviceConnected = CountDownLatch(1)

--- a/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
+++ b/audioswitch/src/main/java/com/twilio/audioswitch/AudioSwitch.kt
@@ -439,7 +439,7 @@ class AudioSwitch {
         audioDeviceChangeListener = null
     }
 
-    private fun getBluetoothHeadsetManager() : BluetoothHeadsetManager? {
+    private fun getBluetoothHeadsetManager(): BluetoothHeadsetManager? {
         if (bluetoothHeadsetManager == null && hasPermissions()) {
             val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
             bluetoothHeadsetManager = BluetoothHeadsetManager.newInstance(

--- a/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
+++ b/audioswitch/src/test/java/com/twilio/audioswitch/BaseTest.kt
@@ -1,5 +1,6 @@
 package com.twilio.audioswitch
 
+import android.app.Application
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothClass
 import android.bluetooth.BluetoothDevice
@@ -30,7 +31,10 @@ open class BaseTest {
         whenever(mock.name).thenReturn(DEVICE_NAME)
         whenever(mock.bluetoothClass).thenReturn(bluetoothClass)
     }
-    internal val context = mock<Context>()
+    internal val application = mock<Application>()
+    internal val context = mock<Context>() {
+        whenever(mock.applicationContext).thenReturn(application)
+    }
     internal val bluetoothListener = mock<BluetoothHeadsetConnectionListener>()
     internal val logger = UnitTestLogger()
     internal val audioManager = setupAudioManagerMock()

--- a/ui-test-args.yaml
+++ b/ui-test-args.yaml
@@ -4,9 +4,9 @@ integration-tests:
   app: audioswitch/ftl/app-debug.apk
   test: audioswitch/build/outputs/apk/androidTest/debug/audioswitch-debug-androidTest.apk
   device:
-    - {model: griffin, version: 24}
-    - {model: starqlteue, version: 26}
+    - {model: austin, version: 33}
+    - {model: starlte, version: 29}
     - {model: crownqlteue, version: 29}
     - {model: cactus, version: 27}
-    - {model: q2q, version: 31}
+    - {model: q4q, version: 33}
     - {model: redfin, version: 30}


### PR DESCRIPTION
## Description

- Fixed issue where the audio device list is not updated after a permissions request
- Fixed issue where BluetoothHeadsetManager were being created more than necessary

## Breakdown

- Upon an activity resume, the device list is updated
- 'instance' method replaces with method that updates bluetoothHeadsetManager member
- Updated FTL device list

## Validation

- Tested with RN client
- Ran device tests

## Additional Notes

None

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
