### PR TITLE
fix 1.2.5 release failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
       - run:
           name: Publish AudioSwitch release
           command: |
-            ./gradlew -q sonatypeAudioSwitchReleaseUpload --dry-run
+            ./gradlew -q sonatypeAudioSwitchReleaseUpload
 
 executors:
   build-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
       - run:
           name: Publish AudioSwitch release
           command: |
-            ./gradlew -q sonatypeAudioSwitchReleaseUpload
+            ./gradlew -q sonatypeAudioSwitchReleaseUpload --dry-run
 
 executors:
   build-executor:

--- a/build.gradle
+++ b/build.gradle
@@ -199,12 +199,12 @@ tasks.register('sonatypeAudioSwitchReleaseUpload', RootGradleBuild) {
     buildFile = file('build.gradle')
     tasks = ['assembleRelease', 'publishAudioSwitchReleasePublicationToSonatypeRepository', 'closeAndReleaseSonatypeStagingRepository']
     startParameter.projectProperties += gradle.startParameter.projectProperties + [
-            'signing.keyId'            : "${getPropertyValue("SIGNING_KEY_ID")}",
-            'signing.password'         : "${getPropertyValue("SIGNING_PASSWORD")}",
-            'signing.secretKeyRingFile': "${getPropertyValue("SIGNING_SECRET_KEY_RING_FILE")}",
-            'mavenCentralUsername'     : "${getPropertyValue("MAVEN_CENTRAL_TOKEN_USERNAME")}",
-            'mavenCentralPassword'     : "${getPropertyValue("MAVEN_CENTRAL_TOKEN_PASSWORD")}",
-            'sonatypeStagingProfileId' : "${getPropertyValue("SONATYPE_STAGING_PROFILE_ID")}"
+            'signing.keyId'            : getPropertyValue("SIGNING_KEY_ID"),
+            'signing.password'         : getPropertyValue("SIGNING_PASSWORD"),
+            'signing.secretKeyRingFile': getPropertyValue("SIGNING_SECRET_KEY_RING_FILE"),
+            'mavenCentralUsername'     : getPropertyValue("MAVEN_CENTRAL_TOKEN_USERNAME"),
+            'mavenCentralPassword'     : getPropertyValue("MAVEN_CENTRAL_TOKEN_PASSWORD"),
+            'sonatypeStagingProfileId' : getPropertyValue("SONATYPE_STAGING_PROFILE_ID")
     ]
 }
 


### PR DESCRIPTION
## Description

This should fix the 1.2.5 release failure that was experienced.

## Breakdown

- Updated so that a 'String' instead of a 'GString' object is passed to the maven publishing plugin

## Validation

- Tested a dry run in CI and locally

## Additional Notes

None

## Submission Checklist
 - [ ] The source has been evaluated for semantic versioning changes and are reflected in `gradle.properties`
 - [ ] The `CHANGELOG.md` reflects any **feature**, **bug fixes**, or **known issues** made in the source code
